### PR TITLE
Add reorderable modules grid

### DIFF
--- a/lib/Providers/module_provider.dart
+++ b/lib/Providers/module_provider.dart
@@ -190,4 +190,14 @@ class ModuleProvider with ChangeNotifier {
       setAppropriateParent(element);
     });
   }
+
+  void reorderModules(int oldIndex, int newIndex) {
+    final entries = _modules.entries.toList();
+    final entry = entries.removeAt(oldIndex);
+    entries.insert(newIndex, entry);
+    _modules
+      ..clear()
+      ..addEntries(entries);
+    notifyListeners();
+  }
 }

--- a/lib/Widgets/overview_screen_grid_widget.dart
+++ b/lib/Widgets/overview_screen_grid_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:reorderable_grid_view/reorderable_grid_view.dart';
 
 import '../Providers/module_provider.dart';
 import './module_widget.dart';
@@ -22,7 +23,7 @@ class OverviewScreenGridWidget extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 0.0),
                 child: SizedBox(
                   height: MediaQuery.of(context).size.height * 0.45,
-                  child: GridView.builder(
+                  child: ReorderableGridView.builder(
                     gridDelegate:
                         const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 2,
@@ -31,6 +32,7 @@ class OverviewScreenGridWidget extends StatelessWidget {
                       mainAxisSpacing: 20,
                     ),
                     itemBuilder: (_, i) => Container(
+                      key: ValueKey(moduleProvider.modules.keys.elementAt(i)),
                       decoration: BoxDecoration(
                         boxShadow: [
                           BoxShadow(
@@ -48,6 +50,9 @@ class OverviewScreenGridWidget extends StatelessWidget {
                     ),
                     itemCount: moduleProvider.modules.entries.length,
                     padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                    onReorder: (oldIndex, newIndex) {
+                      moduleProvider.reorderModules(oldIndex, newIndex);
+                    },
                   ),
                 ),
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   modal_bottom_sheet: ^3.0.0
   flutter_slidable: ^4.0.0
   hive: ^2.2.3
+  reorderable_grid_view: ^2.2.8
   
 
 


### PR DESCRIPTION
## Summary
- add reorderable_grid_view dependency
- enable reorderable grid in module overview
- keep module order with new provider method

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68414b1d7c408325ae3ffa0ca26defe0