### PR TITLE
Enable editing & reordering of module contributors

### DIFF
--- a/lib/Providers/module_provider.dart
+++ b/lib/Providers/module_provider.dart
@@ -221,4 +221,15 @@ class ModuleProvider with ChangeNotifier {
       ..addEntries(entries);
     notifyListeners();
   }
+
+  void reorderContributors(
+      {required MarkItem parent, required int oldIndex, required int newIndex}) {
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+    final item = parent.contributors.removeAt(oldIndex) as MarkItem;
+    parent.contributors.insert(newIndex, item);
+    parent.save();
+    notifyListeners();
+  }
 }

--- a/lib/Screens/contributor_information_screen.dart
+++ b/lib/Screens/contributor_information_screen.dart
@@ -8,6 +8,7 @@ import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
 import '../Widgets/padded_list_heading_widget.dart';
+import '../Widgets/contributor_creation_user_input_widget.dart';
 
 class ContributorInformationScreen extends StatefulWidget {
   static const routeName = "/ContributorInformation";
@@ -41,6 +42,25 @@ class _ContributorInformationScreenState
       appBar: AppBar(
         title: Text(parent.name),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.edit_rounded),
+            onPressed: () {
+              showModalBottomSheet(
+                isScrollControlled: true,
+                context: context,
+                shape: const RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.vertical(bottom: Radius.zero, top: Radius.circular(14)),
+                ),
+                builder: (ctx) => ContributorCreationUserInputWidget(
+                  screenHeight: 0,
+                  screenWidth: MediaQuery.of(ctx).size.width,
+                  parent: null,
+                  toEdit: parent,
+                ),
+              );
+            },
+          ),
           AddContributorPopUpModal(
             parent: parent,
             toEdit: null,
@@ -63,10 +83,18 @@ class _ContributorInformationScreenState
             const PaddedListHeadingWidget(headingName: "Contributors"),
           if (parent.contributors.isNotEmpty)
             Expanded(
-              child: ListView.builder(
+              child: ReorderableListView.builder(
+                onReorder: (oldIndex, newIndex) {
+                  moduleProvider.reorderContributors(
+                    parent: parent,
+                    oldIndex: oldIndex,
+                    newIndex: newIndex,
+                  );
+                },
                 itemCount: parent.contributors.length,
                 itemBuilder: (ctx, index) {
                   return Padding(
+                    key: ValueKey(parent.contributors[index].key),
                     padding: (index < (parent.contributors.length - 1))
                         ? const EdgeInsets.only(bottom: 12)
                         : const EdgeInsets.all(0),

--- a/lib/Screens/module_information_screen.dart
+++ b/lib/Screens/module_information_screen.dart
@@ -8,6 +8,7 @@ import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
 import '../Widgets/padded_list_heading_widget.dart';
+import '../Widgets/module_creation_user_input.dart';
 
 class ModuleInformationScreen extends StatefulWidget {
   static const routeName = "/moduleInformation";
@@ -42,6 +43,22 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
       appBar: AppBar(
         title: Text(moduleProvider.modules[moduleName]!.name),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.edit_rounded),
+            onPressed: () {
+              showModalBottomSheet(
+                isScrollControlled: true,
+                context: context,
+                shape: const RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.vertical(bottom: Radius.zero, top: Radius.circular(14)),
+                ),
+                builder: (ctx) => ModuleCreationUserInputWidget(
+                  toEdit: moduleProvider.modules[moduleName]!,
+                ),
+              );
+            },
+          ),
           AddContributorPopUpModal(
             parent: moduleProvider.modules[moduleName]!,
             toEdit: null,
@@ -62,11 +79,20 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
             const PaddedListHeadingWidget(headingName: "Contributors"),
           if (moduleProvider.modules[moduleName]!.contributors.isNotEmpty)
             Expanded(
-              child: ListView.builder(
+              child: ReorderableListView.builder(
+                onReorder: (oldIndex, newIndex) {
+                  moduleProvider.reorderContributors(
+                    parent: moduleProvider.modules[moduleName]!,
+                    oldIndex: oldIndex,
+                    newIndex: newIndex,
+                  );
+                },
                 itemCount:
-                    moduleProvider.modules[moduleName]?.contributors.length,
+                    moduleProvider.modules[moduleName]!.contributors.length,
                 itemBuilder: (ctx, index) {
                   return Padding(
+                    key: ValueKey(moduleProvider
+                        .modules[moduleName]!.contributors[index].key),
                     padding: const EdgeInsets.symmetric(vertical: 6),
                     child: ContributorWidget(
                         contributor: (moduleProvider.modules[moduleName]!


### PR DESCRIPTION
## Summary
- enable editing modules from the module detail screen
- enable editing contributors from the contributor detail screen
- allow contributors to be rearranged via new provider method

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416597fcd083259436a7ca1c86c623