### PR TITLE
Fix module editing with contributors

### DIFF
--- a/lib/Providers/module_provider.dart
+++ b/lib/Providers/module_provider.dart
@@ -198,7 +198,12 @@ class ModuleProvider with ChangeNotifier {
     required double credits,
   }) {
     _modules[id]!.name = name;
-    _modules[id]!.mark = mark / 100;
+    // Only update the mark if the module has no contributors. When a module
+    // contains contributors its mark is calculated automatically based on its
+    // children, therefore it should remain untouched here.
+    if (_modules[id]!.contributors.isEmpty) {
+      _modules[id]!.mark = mark / 100;
+    }
     _modules[id]!.credits = credits;
     notifyListeners();
 

--- a/lib/Widgets/module_creation_user_input.dart
+++ b/lib/Widgets/module_creation_user_input.dart
@@ -180,9 +180,7 @@ class _ModuleCreationUserInputWidgetState
               },
               child: widget.toEdit == null
                   ? const Text("Add")
-                  : (widget.toEdit!.contributors.isEmpty)
-                      ? const Text("Update")
-                      : const Text("Rename"),
+                  : const Text("Update"),
             ),
           ),
         ),
@@ -230,9 +228,7 @@ class ModuleCreationHeadingWidget extends StatelessWidget {
       alignment: Alignment.center,
       child: (toEdit == null)
           ? const PaddedListHeadingWidget(headingName: "Add module")
-          : ((toEdit!.contributors.isEmpty)
-              ? const PaddedListHeadingWidget(headingName: "Update module")
-              : const PaddedListHeadingWidget(headingName: "Rename module")),
+          : const PaddedListHeadingWidget(headingName: "Update module"),
     );
   }
 }


### PR DESCRIPTION
## Summary
- allow updating module name and credits even if it has contributors
- show a consistent 'Update' label when editing modules
- keep computed marks intact for modules with contributors

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841841f50248325a42fbc324f9e7bad