### PR TITLE
Improve layout responsiveness for iOS and larger screens

### DIFF
--- a/lib/Screens/overview_screen.dart
+++ b/lib/Screens/overview_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -13,10 +15,67 @@ class OverviewScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Provider.of<SystemInformationProvider>(context).initialize(context);
+    final orientation = MediaQuery.of(context).orientation;
+
+    final Widget body = (orientation == Orientation.portrait)
+        ? const Column(
+            children: <Widget>[
+              OverviewScreenAverageCarouselWidget(),
+              Expanded(child: OverviewScreenGridWidget()),
+            ],
+          )
+        : const Row(
+            children: [
+              Expanded(
+                flex: 2,
+                child: OverviewScreenAverageCarouselWidget(),
+              ),
+              Expanded(
+                flex: 3,
+                child: OverviewScreenGridWidget(),
+              ),
+            ],
+          );
+
+    if (Platform.isIOS) {
+      return CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(
+          middle: const Text('Markulator'),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              Navigator.of(context).pushNamed(SettingsScreen.routeName);
+            },
+            child: const Icon(CupertinoIcons.settings),
+          ),
+        ),
+        child: Stack(
+          children: [
+            SafeArea(child: body),
+            Positioned(
+              bottom: 16,
+              right: 16,
+              child: CupertinoButton.filled(
+                onPressed: () {
+                  showCupertinoModalPopup(
+                    context: context,
+                    builder: (ctx) => Material(
+                      child: ModuleCreationUserInputWidget(toEdit: null),
+                    ),
+                  );
+                },
+                child: const Icon(CupertinoIcons.add),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        title: const Text("Markulator"),
+        title: const Text('Markulator'),
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
@@ -26,12 +85,7 @@ class OverviewScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: const Column(
-        children: <Widget>[
-          OverviewScreenAverageCarouselWidget(),
-          OverviewScreenGridWidget(),
-        ],
-      ),
+      body: body,
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           showModalBottomSheet(

--- a/lib/Widgets/average_percentage_widget.dart
+++ b/lib/Widgets/average_percentage_widget.dart
@@ -47,9 +47,15 @@ class AveragePercentageWidget extends StatelessWidget {
                 ),
                 child: Padding(
                   padding: EdgeInsets.only(top: constraints.maxHeight * 0.3),
-                  child: PercentageIndicatorWidget(
-                    percentage: percentage,
-                    indicatorSize: Size.large,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxHeight: 300,
+                      maxWidth: 400,
+                    ),
+                    child: PercentageIndicatorWidget(
+                      percentage: percentage,
+                      indicatorSize: Size.large,
+                    ),
                   ),
                 ),
               ),

--- a/lib/Widgets/module_widget.dart
+++ b/lib/Widgets/module_widget.dart
@@ -25,10 +25,17 @@ class _ModuleWidgetState extends State<ModuleWidget> {
 
   late ModuleProvider moduleProvider;
 
+  int _getCrossAxisCount(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= 900) return 4;
+    if (width >= 600) return 3;
+    return 2;
+  }
+
   @override
   void didChangeDependencies() {
     screenHeight = MediaQuery.of(context).size.height;
-    gridItemWidth = (MediaQuery.of(context).size.width / 2) - 20;
+    gridItemWidth = (MediaQuery.of(context).size.width / _getCrossAxisCount(context)) - 20;
     moduleProvider = Provider.of<ModuleProvider>(context);
     super.didChangeDependencies();
   }
@@ -98,8 +105,10 @@ class _ModuleWidgetState extends State<ModuleWidget> {
             children: [
               ConstrainedBox(
                 constraints: BoxConstraints(
-                  maxHeight: screenHeight * 0.14,
-                  maxWidth: double.infinity,
+                  maxHeight: (screenHeight * 0.14 > 300)
+                      ? 300
+                      : screenHeight * 0.14,
+                  maxWidth: 400,
                   minHeight: 10,
                   minWidth: double.infinity,
                 ),

--- a/lib/Widgets/overview_screen_grid_widget.dart
+++ b/lib/Widgets/overview_screen_grid_widget.dart
@@ -12,6 +12,13 @@ class OverviewScreenGridWidget extends StatelessWidget {
     super.key,
   });
 
+  int _getCrossAxisCount(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= 900) return 4;
+    if (width >= 600) return 3;
+    return 2;
+  }
+
   @override
   Widget build(BuildContext context) {
     final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
@@ -24,9 +31,8 @@ class OverviewScreenGridWidget extends StatelessWidget {
                 child: SizedBox(
                   height: MediaQuery.of(context).size.height * 0.45,
                   child: ReorderableGridView.builder(
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: _getCrossAxisCount(context),
                       childAspectRatio: 1.1,
                       crossAxisSpacing: 14,
                       mainAxisSpacing: 20,

--- a/lib/Widgets/percentage_indicator_widget.dart
+++ b/lib/Widgets/percentage_indicator_widget.dart
@@ -34,26 +34,32 @@ class PercentageIndicatorWidget extends StatelessWidget {
     return Stack(
       children: [
         Center(
-          child: AspectRatio(
-            aspectRatio: 3 / 4,
-            child: CircularPercentIndicator(
-              radius: (indicatorSize == Size.small)
-                  ? screenHeight * 0.05
-                  : screenHeight * 0.14,
-              lineWidth: (indicatorSize == Size.small)
-                  ? screenHeight * 0.013
-                  : screenHeight * 0.03,
-              percent: percentage,
-              progressColor: getColor(percentage, ColorType.progressColor),
-              backgroundColor:
-                  (getColor(percentage, ColorType.backgroundColor))!,
-              circularStrokeCap: CircularStrokeCap.round,
-              animation: true,
-              animationDuration: 1250,
-              arcType: (indicatorSize == Size.large) ? ArcType.HALF : null,
-              arcBackgroundColor: (indicatorSize == Size.large)
-                  ? getColor(percentage, ColorType.backgroundColor)
-                  : null,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxHeight: 300,
+              maxWidth: 400,
+            ),
+            child: AspectRatio(
+              aspectRatio: 3 / 4,
+              child: CircularPercentIndicator(
+                radius: (indicatorSize == Size.small)
+                    ? screenHeight * 0.05
+                    : screenHeight * 0.14,
+                lineWidth: (indicatorSize == Size.small)
+                    ? screenHeight * 0.013
+                    : screenHeight * 0.03,
+                percent: percentage,
+                progressColor: getColor(percentage, ColorType.progressColor),
+                backgroundColor:
+                    (getColor(percentage, ColorType.backgroundColor))!,
+                circularStrokeCap: CircularStrokeCap.round,
+                animation: true,
+                animationDuration: 1250,
+                arcType: (indicatorSize == Size.large) ? ArcType.HALF : null,
+                arcBackgroundColor: (indicatorSize == Size.large)
+                    ? getColor(percentage, ColorType.backgroundColor)
+                    : null,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- support orientation with Cupertino and Material scaffolds
- adjust grid cross axis count based on available width
- limit percentage indicator sizes

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68428d112f3c83258c323d7c09e1f8cf