### PR TITLE
Improve responsive design with Cupertino support

### DIFF
--- a/lib/Screens/contributor_information_screen.dart
+++ b/lib/Screens/contributor_information_screen.dart
@@ -1,9 +1,10 @@
+import 'dart:io' show Platform;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../Model/module_model.dart';
 import '../Providers/module_provider.dart';
-import '../Providers/system_information_provider.dart';
 import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
@@ -22,14 +23,10 @@ class ContributorInformationScreen extends StatefulWidget {
 class _ContributorInformationScreenState
     extends State<ContributorInformationScreen> {
   late MarkItem parent;
-
-  late SystemInformationProvider systemInformationProvider;
-  late SystemInformationProvider symoduleProviderstemInformationProvider;
   late ModuleProvider moduleProvider;
 
   @override
   void didChangeDependencies() {
-    systemInformationProvider = Provider.of<SystemInformationProvider>(context);
     parent = ModalRoute.of(context)!.settings.arguments as MarkItem;
     moduleProvider = Provider.of<ModuleProvider>(context);
     super.didChangeDependencies();
@@ -37,6 +34,91 @@ class _ContributorInformationScreenState
 
   @override
   Widget build(BuildContext context) {
+    final Widget content = LayoutBuilder(
+      builder: (ctx, constraints) {
+        final double chartHeight = constraints.maxHeight * 0.4;
+        return Column(
+          children: [
+            SizedBox(
+              width: double.infinity,
+              height: chartHeight,
+              child: AveragePercentageWidget(
+                percentage: parent.mark,
+                heading: "${parent.name} average",
+              ),
+            ),
+            if (parent.contributors.isNotEmpty)
+              const PaddedListHeadingWidget(headingName: "Contributors"),
+            if (parent.contributors.isNotEmpty)
+              Expanded(
+                child: ReorderableListView.builder(
+                  onReorder: (oldIndex, newIndex) {
+                    moduleProvider.reorderContributors(
+                      parent: parent,
+                      oldIndex: oldIndex,
+                      newIndex: newIndex,
+                    );
+                  },
+                  itemCount: parent.contributors.length,
+                  itemBuilder: (ctx, index) {
+                    return Padding(
+                      key: ValueKey(parent.contributors[index].key),
+                      padding: (index < (parent.contributors.length - 1))
+                          ? const EdgeInsets.only(bottom: 12)
+                          : const EdgeInsets.all(0),
+                      child: ContributorWidget(
+                        contributor: (parent.contributors[index] as MarkItem),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            if (parent.contributors.isEmpty)
+              const Expanded(
+                child: Center(
+                  child: Text(
+                    "No contributors specified.",
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+
+    if (Platform.isIOS) {
+      return CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(
+          middle: Text(parent.name),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: () {
+                  showCupertinoModalPopup(
+                    context: context,
+                    builder: (ctx) => Material(
+                      child: ContributorCreationUserInputWidget(
+                        screenHeight: 0,
+                        screenWidth: MediaQuery.of(ctx).size.width,
+                        parent: null,
+                        toEdit: parent,
+                      ),
+                    ),
+                  );
+                },
+                child: const Icon(CupertinoIcons.pencil),
+              ),
+              AddContributorPopUpModal(parent: parent, toEdit: null),
+            ],
+          ),
+        ),
+        child: SafeArea(child: content),
+      );
+    }
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
@@ -49,8 +131,10 @@ class _ContributorInformationScreenState
                 isScrollControlled: true,
                 context: context,
                 shape: const RoundedRectangleBorder(
-                  borderRadius:
-                      BorderRadius.vertical(bottom: Radius.zero, top: Radius.circular(14)),
+                  borderRadius: BorderRadius.vertical(
+                    bottom: Radius.zero,
+                    top: Radius.circular(14),
+                  ),
                 ),
                 builder: (ctx) => ContributorCreationUserInputWidget(
                   screenHeight: 0,
@@ -61,60 +145,10 @@ class _ContributorInformationScreenState
               );
             },
           ),
-          AddContributorPopUpModal(
-            parent: parent,
-            toEdit: null,
-          ),
+          AddContributorPopUpModal(parent: parent, toEdit: null),
         ],
       ),
-      body: Column(
-        children: [
-          SizedBox(
-            width: double.infinity,
-            height: systemInformationProvider.androidAvailableScreenHeight(
-                    context: context) *
-                0.4,
-            child: AveragePercentageWidget(
-              percentage: parent.mark,
-              heading: "${parent.name} average",
-            ),
-          ),
-          if (parent.contributors.isNotEmpty)
-            const PaddedListHeadingWidget(headingName: "Contributors"),
-          if (parent.contributors.isNotEmpty)
-            Expanded(
-              child: ReorderableListView.builder(
-                onReorder: (oldIndex, newIndex) {
-                  moduleProvider.reorderContributors(
-                    parent: parent,
-                    oldIndex: oldIndex,
-                    newIndex: newIndex,
-                  );
-                },
-                itemCount: parent.contributors.length,
-                itemBuilder: (ctx, index) {
-                  return Padding(
-                    key: ValueKey(parent.contributors[index].key),
-                    padding: (index < (parent.contributors.length - 1))
-                        ? const EdgeInsets.only(bottom: 12)
-                        : const EdgeInsets.all(0),
-                    child: ContributorWidget(
-                        contributor: (parent.contributors[index] as MarkItem)),
-                  );
-                },
-              ),
-            ),
-          if (parent.contributors.isEmpty)
-            const Expanded(
-              child: Center(
-                child: Text(
-                  "No contributors specified.",
-                  style: TextStyle(fontSize: 18),
-                ),
-              ),
-            ),
-        ],
-      ),
+      body: content,
     );
   }
 }

--- a/lib/Screens/module_information_screen.dart
+++ b/lib/Screens/module_information_screen.dart
@@ -1,9 +1,10 @@
+import 'dart:io' show Platform;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../Model/module_model.dart';
 import '../Providers/module_provider.dart';
-import '../Providers/system_information_provider.dart';
 import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
@@ -20,24 +21,111 @@ class ModuleInformationScreen extends StatefulWidget {
 }
 
 class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
-  late SystemInformationProvider systemInformationProvider;
-  late double screenHeight;
   late ModuleProvider moduleProvider;
   late int moduleName;
 
   @override
   void didChangeDependencies() {
     moduleName = ModalRoute.of(context)!.settings.arguments as int;
-    systemInformationProvider = Provider.of<SystemInformationProvider>(context);
-
-    screenHeight = systemInformationProvider.androidAvailableScreenHeight(
-        context: context);
     moduleProvider = Provider.of<ModuleProvider>(context);
     super.didChangeDependencies();
   }
 
   @override
   Widget build(BuildContext context) {
+    final Widget content = LayoutBuilder(
+      builder: (ctx, constraints) {
+        final double chartHeight = constraints.maxHeight * 0.4;
+        return Column(
+          children: [
+            SizedBox(
+              width: double.infinity,
+              height: chartHeight,
+              child: AveragePercentageWidget(
+                percentage: moduleProvider.averageMark(moduleName),
+                heading: "${moduleProvider.modules[moduleName]!.name} average",
+              ),
+            ),
+            if (moduleProvider.modules[moduleName]!.contributors.isNotEmpty)
+              const PaddedListHeadingWidget(headingName: "Contributors"),
+            if (moduleProvider.modules[moduleName]!.contributors.isNotEmpty)
+              Expanded(
+                child: ReorderableListView.builder(
+                  onReorder: (oldIndex, newIndex) {
+                    moduleProvider.reorderContributors(
+                      parent: moduleProvider.modules[moduleName]!,
+                      oldIndex: oldIndex,
+                      newIndex: newIndex,
+                    );
+                  },
+                  itemCount:
+                      moduleProvider.modules[moduleName]!.contributors.length,
+                  itemBuilder: (ctx, index) {
+                    return Padding(
+                      key: ValueKey(
+                        moduleProvider
+                            .modules[moduleName]!
+                            .contributors[index]
+                            .key,
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: ContributorWidget(
+                        contributor:
+                            (moduleProvider
+                                    .modules[moduleName]!
+                                    .contributors[index])
+                                as MarkItem,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            if (moduleProvider.modules[moduleName]!.contributors.isEmpty)
+              const Expanded(
+                child: Center(
+                  child: Text(
+                    "No Contributors available.",
+                    style: TextStyle(fontSize: 18),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+
+    if (Platform.isIOS) {
+      return CupertinoPageScaffold(
+        navigationBar: CupertinoNavigationBar(
+          middle: Text(moduleProvider.modules[moduleName]!.name),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: () {
+                  showCupertinoModalPopup(
+                    context: context,
+                    builder: (ctx) => Material(
+                      child: ModuleCreationUserInputWidget(
+                        toEdit: moduleProvider.modules[moduleName]!,
+                      ),
+                    ),
+                  );
+                },
+                child: const Icon(CupertinoIcons.pencil),
+              ),
+              AddContributorPopUpModal(
+                parent: moduleProvider.modules[moduleName]!,
+                toEdit: null,
+              ),
+            ],
+          ),
+        ),
+        child: SafeArea(child: content),
+      );
+    }
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
@@ -50,8 +138,10 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
                 isScrollControlled: true,
                 context: context,
                 shape: const RoundedRectangleBorder(
-                  borderRadius:
-                      BorderRadius.vertical(bottom: Radius.zero, top: Radius.circular(14)),
+                  borderRadius: BorderRadius.vertical(
+                    bottom: Radius.zero,
+                    top: Radius.circular(14),
+                  ),
                 ),
                 builder: (ctx) => ModuleCreationUserInputWidget(
                   toEdit: moduleProvider.modules[moduleName]!,
@@ -65,53 +155,7 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
           ),
         ],
       ),
-      body: Column(
-        children: [
-          SizedBox(
-            width: double.infinity,
-            height: screenHeight * 0.4,
-            child: AveragePercentageWidget(
-              percentage: moduleProvider.averageMark(moduleName),
-              heading: "${moduleProvider.modules[moduleName]!.name} average",
-            ),
-          ),
-          if (moduleProvider.modules[moduleName]!.contributors.isNotEmpty)
-            const PaddedListHeadingWidget(headingName: "Contributors"),
-          if (moduleProvider.modules[moduleName]!.contributors.isNotEmpty)
-            Expanded(
-              child: ReorderableListView.builder(
-                onReorder: (oldIndex, newIndex) {
-                  moduleProvider.reorderContributors(
-                    parent: moduleProvider.modules[moduleName]!,
-                    oldIndex: oldIndex,
-                    newIndex: newIndex,
-                  );
-                },
-                itemCount:
-                    moduleProvider.modules[moduleName]!.contributors.length,
-                itemBuilder: (ctx, index) {
-                  return Padding(
-                    key: ValueKey(moduleProvider
-                        .modules[moduleName]!.contributors[index].key),
-                    padding: const EdgeInsets.symmetric(vertical: 6),
-                    child: ContributorWidget(
-                        contributor: (moduleProvider.modules[moduleName]!
-                            .contributors[index]) as MarkItem),
-                  );
-                },
-              ),
-            ),
-          if (moduleProvider.modules[moduleName]!.contributors.isEmpty)
-            const Expanded(
-              child: Center(
-                child: Text(
-                  "No Contributors available.",
-                  style: TextStyle(fontSize: 18),
-                ),
-              ),
-            ),
-        ],
-      ),
+      body: content,
     );
   }
 }

--- a/lib/Screens/overview_screen.dart
+++ b/lib/Screens/overview_screen.dart
@@ -15,27 +15,31 @@ class OverviewScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Provider.of<SystemInformationProvider>(context).initialize(context);
-    final orientation = MediaQuery.of(context).orientation;
+    final Widget body = LayoutBuilder(
+      builder: (ctx, constraints) {
+        final bool isWide = constraints.maxWidth > 600;
+        final double carouselHeight = isWide
+            ? constraints.maxHeight
+            : constraints.maxHeight * 0.4;
+        final carousel = OverviewScreenAverageCarouselWidget(
+          height: carouselHeight,
+        );
 
-    final Widget body = (orientation == Orientation.portrait)
-        ? const Column(
-            children: <Widget>[
-              OverviewScreenAverageCarouselWidget(),
-              Expanded(child: OverviewScreenGridWidget()),
-            ],
-          )
-        : const Row(
-            children: [
-              Expanded(
-                flex: 2,
-                child: OverviewScreenAverageCarouselWidget(),
-              ),
-              Expanded(
-                flex: 3,
-                child: OverviewScreenGridWidget(),
-              ),
-            ],
-          );
+        return isWide
+            ? Row(
+                children: [
+                  Expanded(flex: 2, child: carousel),
+                  const Expanded(flex: 3, child: OverviewScreenGridWidget()),
+                ],
+              )
+            : Column(
+                children: [
+                  carousel,
+                  const Expanded(child: OverviewScreenGridWidget()),
+                ],
+              );
+      },
+    );
 
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
@@ -93,11 +97,11 @@ class OverviewScreen extends StatelessWidget {
             context: context,
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.vertical(
-                  bottom: Radius.zero, top: Radius.circular(14)),
+                bottom: Radius.zero,
+                top: Radius.circular(14),
+              ),
             ),
-            builder: (ctx) => const ModuleCreationUserInputWidget(
-              toEdit: null,
-            ),
+            builder: (ctx) => const ModuleCreationUserInputWidget(toEdit: null),
           );
         },
         icon: const Icon(Icons.add),

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../Providers/cloud_provider.dart';
@@ -9,45 +11,54 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cloud = Provider.of<CloudProvider>(context);
+    final Widget content = Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SwitchListTile(
+            title: const Text('Store data in cloud'),
+            value: cloud.cloudEnabled,
+            onChanged: (val) {
+              cloud.setCloudEnabled(val);
+            },
+          ),
+          const SizedBox(height: 20),
+          if (cloud.user == null)
+            ElevatedButton(
+              onPressed: () async {
+                await cloud.signInWithGoogle();
+              },
+              child: const Text('Sign in with Google'),
+            )
+          else
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
+                const SizedBox(height: 10),
+                ElevatedButton(
+                  onPressed: () async {
+                    await cloud.signOut();
+                  },
+                  child: const Text('Logout'),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+
+    if (Platform.isIOS) {
+      return CupertinoPageScaffold(
+        navigationBar: const CupertinoNavigationBar(middle: Text('Settings')),
+        child: SafeArea(child: content),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            SwitchListTile(
-              title: const Text('Store data in cloud'),
-              value: cloud.cloudEnabled,
-              onChanged: (val) {
-                cloud.setCloudEnabled(val);
-              },
-            ),
-            const SizedBox(height: 20),
-            if (cloud.user == null)
-              ElevatedButton(
-                onPressed: () async {
-                  await cloud.signInWithGoogle();
-                },
-                child: const Text('Sign in with Google'),
-              )
-            else
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
-                  const SizedBox(height: 10),
-                  ElevatedButton(
-                    onPressed: () async {
-                      await cloud.signOut();
-                    },
-                    child: const Text('Logout'),
-                  ),
-                ],
-              ),
-          ],
-        ),
-      ),
+      body: content,
     );
   }
 }

--- a/lib/Widgets/add_contributor_pop_up_modal_widget.dart
+++ b/lib/Widgets/add_contributor_pop_up_modal_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../Model/module_model.dart';
@@ -26,24 +28,43 @@ class _AddContributorPopUpModalState extends State<AddContributorPopUpModal> {
       child: GestureDetector(
         child: const Icon(Icons.add),
         onTap: () {
-          showModalBottomSheet(
+          if (Platform.isIOS) {
+            showCupertinoModalPopup(
+              context: context,
+              builder: (ctx) => CupertinoPageScaffold(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 30),
+                  child: ContributorCreationUserInputWidget(
+                    screenHeight: 0,
+                    screenWidth: MediaQuery.of(ctx).size.width,
+                    parent: widget.parent,
+                    toEdit: widget.toEdit,
+                  ),
+                ),
+              ),
+            );
+          } else {
+            showModalBottomSheet(
               isScrollControlled: true,
               isDismissible: true,
               context: context,
               shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(
-                bottom: Radius.zero,
-                top: Radius.circular(14),
-              )),
+                borderRadius: BorderRadius.vertical(
+                  bottom: Radius.zero,
+                  top: Radius.circular(14),
+                ),
+              ),
               builder: (ctx) => Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 30),
-                    child: ContributorCreationUserInputWidget(
-                      screenHeight: 0,
-                      screenWidth: MediaQuery.of(ctx).size.width,
-                      parent: widget.parent,
-                      toEdit: widget.toEdit,
-                    ),
-                  ));
+                padding: const EdgeInsets.symmetric(horizontal: 30),
+                child: ContributorCreationUserInputWidget(
+                  screenHeight: 0,
+                  screenWidth: MediaQuery.of(ctx).size.width,
+                  parent: widget.parent,
+                  toEdit: widget.toEdit,
+                ),
+              ),
+            );
+          }
         },
       ),
     );

--- a/lib/Widgets/overview_screen_average_carousel_widget.dart
+++ b/lib/Widgets/overview_screen_average_carousel_widget.dart
@@ -5,7 +5,8 @@ import '../Providers/module_provider.dart';
 import './average_percentage_widget.dart';
 
 class OverviewScreenAverageCarouselWidget extends StatefulWidget {
-  const OverviewScreenAverageCarouselWidget({super.key});
+  final double height;
+  const OverviewScreenAverageCarouselWidget({super.key, required this.height});
 
   @override
   State<OverviewScreenAverageCarouselWidget> createState() =>
@@ -34,7 +35,7 @@ class _OverviewScreenAverageCarouselWidgetState
     final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
     return SizedBox(
       width: double.infinity,
-      height: MediaQuery.of(context).size.height * 0.4,
+      height: widget.height,
       child: Column(
         children: [
           Expanded(
@@ -73,7 +74,7 @@ class _OverviewScreenAverageCarouselWidgetState
                 ),
               ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/lib/Widgets/overview_screen_grid_widget.dart
+++ b/lib/Widgets/overview_screen_grid_widget.dart
@@ -8,9 +8,7 @@ import 'overview_screen_no_modules_available_widget.dart';
 import 'padded_list_heading_widget.dart';
 
 class OverviewScreenGridWidget extends StatelessWidget {
-  const OverviewScreenGridWidget({
-    super.key,
-  });
+  const OverviewScreenGridWidget({super.key});
 
   int _getCrossAxisCount(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
@@ -23,46 +21,54 @@ class OverviewScreenGridWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
     return (moduleProvider.modules.isNotEmpty)
-        ? Column(
-            children: [
-              const PaddedListHeadingWidget(headingName: "Modules"),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 0.0),
-                child: SizedBox(
-                  height: MediaQuery.of(context).size.height * 0.45,
-                  child: ReorderableGridView.builder(
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: _getCrossAxisCount(context),
-                      childAspectRatio: 1.1,
-                      crossAxisSpacing: 14,
-                      mainAxisSpacing: 20,
-                    ),
-                    itemBuilder: (_, i) => Container(
-                      key: ValueKey(moduleProvider.modules.keys.elementAt(i)),
-                      decoration: BoxDecoration(
-                        boxShadow: [
-                          BoxShadow(
-                              color: Colors.blueGrey[300]!,
-                              blurRadius: 2.5,
-                              offset: const Offset(5.0, 7.0)),
-                        ],
-                        borderRadius: BorderRadius.circular(20),
+        ? LayoutBuilder(
+            builder: (ctx, constraints) {
+              return Column(
+                children: [
+                  const PaddedListHeadingWidget(headingName: "Modules"),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                    child: SizedBox(
+                      height: constraints.maxHeight * 0.9,
+                      child: ReorderableGridView.builder(
+                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: _getCrossAxisCount(context),
+                          childAspectRatio: 1.1,
+                          crossAxisSpacing: 14,
+                          mainAxisSpacing: 20,
+                        ),
+                        itemBuilder: (_, i) => Container(
+                          key: ValueKey(
+                            moduleProvider.modules.keys.elementAt(i),
+                          ),
+                          decoration: BoxDecoration(
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.blueGrey[300]!,
+                                blurRadius: 2.5,
+                                offset: const Offset(5.0, 7.0),
+                              ),
+                            ],
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: ModuleWidget(
+                            id: moduleProvider.modules.entries
+                                .elementAt(i)
+                                .value
+                                .key,
+                          ),
+                        ),
+                        itemCount: moduleProvider.modules.entries.length,
+                        padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                        onReorder: (oldIndex, newIndex) {
+                          moduleProvider.reorderModules(oldIndex, newIndex);
+                        },
                       ),
-                      child: ModuleWidget(
-                          id: moduleProvider.modules.entries
-                              .elementAt(i)
-                              .value
-                              .key),
                     ),
-                    itemCount: moduleProvider.modules.entries.length,
-                    padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                    onReorder: (oldIndex, newIndex) {
-                      moduleProvider.reorderModules(oldIndex, newIndex);
-                    },
                   ),
-                ),
-              ),
-            ],
+                ],
+              );
+            },
           )
         : const OverviewScreenNoModulesAvailable();
   }

--- a/lib/Widgets/percentage_indicator_widget.dart
+++ b/lib/Widgets/percentage_indicator_widget.dart
@@ -1,18 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
-import 'package:provider/provider.dart';
+import 'dart:math' as math;
 
-import '../Providers/system_information_provider.dart';
+enum ColorType { progressColor, backgroundColor }
 
-enum ColorType {
-  progressColor,
-  backgroundColor,
-}
-
-enum Size {
-  large,
-  small,
-}
+enum Size { large, small }
 
 class PercentageIndicatorWidget extends StatelessWidget {
   final double percentage;
@@ -26,47 +18,58 @@ class PercentageIndicatorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final systemInformationProvider =
-        Provider.of<SystemInformationProvider>(context);
-    final screenHeight = systemInformationProvider.androidAvailableScreenHeight(
-        context: context);
+    return LayoutBuilder(
+      builder: (ctx, constraints) {
+        final shortestSide = math.min(
+          constraints.maxHeight,
+          constraints.maxWidth,
+        );
+        final radius = (indicatorSize == Size.small)
+            ? shortestSide * 0.4
+            : shortestSide * 0.45;
+        final lineWidth = (indicatorSize == Size.small)
+            ? radius * 0.26
+            : radius * 0.22;
 
-    return Stack(
-      children: [
-        Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(
-              maxHeight: 300,
-              maxWidth: 400,
-            ),
-            child: AspectRatio(
-              aspectRatio: 3 / 4,
-              child: CircularPercentIndicator(
-                radius: (indicatorSize == Size.small)
-                    ? screenHeight * 0.05
-                    : screenHeight * 0.14,
-                lineWidth: (indicatorSize == Size.small)
-                    ? screenHeight * 0.013
-                    : screenHeight * 0.03,
-                percent: percentage,
-                progressColor: getColor(percentage, ColorType.progressColor),
-                backgroundColor:
-                    (getColor(percentage, ColorType.backgroundColor))!,
-                circularStrokeCap: CircularStrokeCap.round,
-                animation: true,
-                animationDuration: 1250,
-                arcType: (indicatorSize == Size.large) ? ArcType.HALF : null,
-                arcBackgroundColor: (indicatorSize == Size.large)
-                    ? getColor(percentage, ColorType.backgroundColor)
-                    : null,
+        return Stack(
+          children: [
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(
+                  maxHeight: 300,
+                  maxWidth: 400,
+                ),
+                child: AspectRatio(
+                  aspectRatio: 3 / 4,
+                  child: CircularPercentIndicator(
+                    radius: radius,
+                    lineWidth: lineWidth,
+                    percent: percentage,
+                    progressColor: getColor(
+                      percentage,
+                      ColorType.progressColor,
+                    ),
+                    backgroundColor: (getColor(
+                      percentage,
+                      ColorType.backgroundColor,
+                    ))!,
+                    circularStrokeCap: CircularStrokeCap.round,
+                    animation: true,
+                    animationDuration: 1250,
+                    arcType: (indicatorSize == Size.large)
+                        ? ArcType.HALF
+                        : null,
+                    arcBackgroundColor: (indicatorSize == Size.large)
+                        ? getColor(percentage, ColorType.backgroundColor)
+                        : null,
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
-        Center(
-          child: getText(),
-        )
-      ],
+            Center(child: getText()),
+          ],
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- adjust `OverviewScreen` layout with `LayoutBuilder` instead of orientation checks
- use a dynamic height `OverviewScreenAverageCarouselWidget`
- make grid and indicator widgets responsive with `LayoutBuilder`
- add Cupertino variants for module & contributor screens, settings screen and contributor popup
- calculate gauge sizes based on available space

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842919473f4832582e5e9563c5cec55