### PR TITLE
Fix iOS visuals and update carousel

### DIFF
--- a/lib/Screens/overview_screen.dart
+++ b/lib/Screens/overview_screen.dart
@@ -18,11 +18,11 @@ class OverviewScreen extends StatelessWidget {
     final Widget body = LayoutBuilder(
       builder: (ctx, constraints) {
         final bool isWide = constraints.maxWidth > 600;
-        final double carouselHeight = isWide
-            ? constraints.maxHeight
-            : constraints.maxHeight * 0.4;
+        final double carouselHeight =
+            isWide ? constraints.maxHeight : constraints.maxHeight * 0.4;
         final carousel = OverviewScreenAverageCarouselWidget(
           height: carouselHeight,
+          scrollDirection: isWide ? Axis.vertical : Axis.horizontal,
         );
 
         return isWide

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -11,42 +11,39 @@ class SettingsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cloud = Provider.of<CloudProvider>(context);
-    final Widget content = Padding(
+    final Widget content = ListView(
       padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SwitchListTile(
-            title: const Text('Store data in cloud'),
-            value: cloud.cloudEnabled,
-            onChanged: (val) {
-              cloud.setCloudEnabled(val);
+      children: [
+        SwitchListTile(
+          title: const Text('Store data in cloud'),
+          value: cloud.cloudEnabled,
+          onChanged: (val) {
+            cloud.setCloudEnabled(val);
+          },
+        ),
+        const SizedBox(height: 20),
+        if (cloud.user == null)
+          ElevatedButton(
+            onPressed: () async {
+              await cloud.signInWithGoogle();
             },
+            child: const Text('Sign in with Google'),
+          )
+        else
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
+              const SizedBox(height: 10),
+              ElevatedButton(
+                onPressed: () async {
+                  await cloud.signOut();
+                },
+                child: const Text('Logout'),
+              ),
+            ],
           ),
-          const SizedBox(height: 20),
-          if (cloud.user == null)
-            ElevatedButton(
-              onPressed: () async {
-                await cloud.signInWithGoogle();
-              },
-              child: const Text('Sign in with Google'),
-            )
-          else
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
-                const SizedBox(height: 10),
-                ElevatedButton(
-                  onPressed: () async {
-                    await cloud.signOut();
-                  },
-                  child: const Text('Logout'),
-                ),
-              ],
-            ),
-        ],
-      ),
+      ],
     );
 
     if (Platform.isIOS) {

--- a/lib/Widgets/overview_screen_average_carousel_widget.dart
+++ b/lib/Widgets/overview_screen_average_carousel_widget.dart
@@ -6,7 +6,12 @@ import './average_percentage_widget.dart';
 
 class OverviewScreenAverageCarouselWidget extends StatefulWidget {
   final double height;
-  const OverviewScreenAverageCarouselWidget({super.key, required this.height});
+  final Axis scrollDirection;
+  const OverviewScreenAverageCarouselWidget({
+    super.key,
+    required this.height,
+    this.scrollDirection = Axis.horizontal,
+  });
 
   @override
   State<OverviewScreenAverageCarouselWidget> createState() =>
@@ -41,6 +46,7 @@ class _OverviewScreenAverageCarouselWidgetState
           Expanded(
             child: PageView(
               controller: _controller,
+              scrollDirection: widget.scrollDirection,
               onPageChanged: (i) {
                 setState(() {
                   _index = i;

--- a/lib/Widgets/padded_list_heading_widget.dart
+++ b/lib/Widgets/padded_list_heading_widget.dart
@@ -14,7 +14,7 @@ class PaddedListHeadingWidget extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(7, 7, 3, 0),
       child: Text(
         headingName,
-        style: const TextStyle(fontSize: 22),
+        style: Theme.of(context).textTheme.titleLarge,
         textAlign: TextAlign.left,
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  cupertino_icons: ^1.0.6
   percent_indicator: ^4.2.5
   provider: ^6.1.5
   modal_bottom_sheet: ^3.0.0


### PR DESCRIPTION
## Summary
- add missing `cupertino_icons` dependency so iOS icons render
- make settings screen scrollable to prevent infinite grey area
- let carousel scroll vertically in wide layouts
- style headings with theme colors

## Testing
- `flutter analyze`
- `flutter test integration_test/app_test.dart` *(fails: Unable to generate build files)*

------
https://chatgpt.com/codex/tasks/task_e_6842994795008325989b57808d213119