### PR TITLE
Improve grid and module sizing

### DIFF
--- a/lib/Widgets/module_widget.dart
+++ b/lib/Widgets/module_widget.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../Providers/module_provider.dart';
-import '../Providers/system_information_provider.dart';
 import '../Screens/module_information_screen.dart';
 import 'module_creation_user_input.dart';
 import 'percentage_indicator_widget.dart';
@@ -19,26 +18,20 @@ class ModuleWidget extends StatefulWidget {
 }
 
 class _ModuleWidgetState extends State<ModuleWidget> {
-  late SystemInformationProvider systemInformationProvider;
-
-  late double screenHeight;
-
   late double gridItemWidth;
 
   late ModuleProvider moduleProvider;
 
   int _getCrossAxisCount(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 900) return 4;
-    if (width >= 600) return 3;
-    return 2;
+    final count = (width / 160).floor();
+    return (count > 0) ? count : 1;
   }
 
   @override
   void didChangeDependencies() {
-    screenHeight = MediaQuery.of(context).size.height;
     gridItemWidth =
-        (MediaQuery.of(context).size.width / _getCrossAxisCount(context)) - 20;
+        MediaQuery.of(context).size.width / _getCrossAxisCount(context);
     moduleProvider = Provider.of<ModuleProvider>(context);
     super.didChangeDependencies();
   }
@@ -62,16 +55,10 @@ class _ModuleWidgetState extends State<ModuleWidget> {
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxHeight: (screenHeight * 0.14 > 300)
-                          ? 300
-                          : screenHeight * 0.14,
-                      maxWidth: 400,
-                      minHeight: 10,
-                      minWidth: double.infinity,
-                    ),
+                  SizedBox(
+                    height: gridItemWidth * 0.6,
                     child: PercentageIndicatorWidget(
                       percentage: module.mark,
                       indicatorSize: Size.small,

--- a/lib/Widgets/overview_screen_grid_widget.dart
+++ b/lib/Widgets/overview_screen_grid_widget.dart
@@ -12,9 +12,8 @@ class OverviewScreenGridWidget extends StatelessWidget {
 
   int _getCrossAxisCount(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 900) return 4;
-    if (width >= 600) return 3;
-    return 2;
+    final count = (width / 160).floor();
+    return (count > 0) ? count : 1;
   }
 
   @override
@@ -33,7 +32,7 @@ class OverviewScreenGridWidget extends StatelessWidget {
                       child: ReorderableGridView.builder(
                         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                           crossAxisCount: _getCrossAxisCount(context),
-                          childAspectRatio: 1.1,
+                          childAspectRatio: 0.8,
                           crossAxisSpacing: 14,
                           mainAxisSpacing: 20,
                         ),


### PR DESCRIPTION
## Summary
- dynamically size grid cross axis based on a 160px minimum width
- adjust grid aspect ratio to allow more vertical space
- size module indicator using grid width and remove unused screen height logic

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429e7a31888325a6d5663ef332acca