### PR TITLE
Add developer DB test screen

### DIFF
--- a/lib/Providers/cloud_provider.dart
+++ b/lib/Providers/cloud_provider.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -128,6 +126,29 @@ class CloudProvider with ChangeNotifier {
       }
     } catch (e) {
       debugPrint('❌ [CloudProvider] Error fetching modules: $e');
+    }
+
+    return null;
+  }
+
+  /// Always fetches the modules for the signed in user regardless of
+  /// `lastUpdated`. Useful for development and testing utilities.
+  Future<List<Map<String, dynamic>>?> fetchAllModules() async {
+    if (!cloudEnabled) return null;
+
+    try {
+      final doc =
+          await _firestore.collection('userModules').doc(user!.uid).get();
+      if (!doc.exists) return null;
+
+      final data = doc.data()!;
+      final remoteTs = (data['lastUpdated'] as Timestamp?)?.toDate();
+      if (remoteTs != null) {
+        _updateLastUpdated(remoteTs);
+      }
+      return List<Map<String, dynamic>>.from(data['modules'] as List);
+    } catch (e) {
+      debugPrint('❌ [CloudProvider] Error fetching all modules: $e');
     }
 
     return null;

--- a/lib/Providers/module_provider.dart
+++ b/lib/Providers/module_provider.dart
@@ -63,6 +63,40 @@ class ModuleProvider with ChangeNotifier {
     }
   }
 
+  /// Clears all locally stored modules.
+  Future<void> clearLocalModules() async {
+    _modules.clear();
+    await _storedModules.clear();
+    notifyListeners();
+  }
+
+  /// Forces uploading the current local modules to the cloud.
+  Future<void> forceUploadToCloud() async {
+    if (_cloudProvider != null) {
+      await _cloudProvider!.syncModules(
+          _modules.values.map((e) => (e as MarkItem).toMap()).toList());
+    }
+  }
+
+  /// Forces fetching modules from the cloud and overwriting local data.
+  Future<void> forceLoadFromCloud() async {
+    if (_cloudProvider != null) {
+      final data = await _cloudProvider!.fetchAllModules();
+      if (data != null) {
+        await _loadFromRemote(data);
+        notifyListeners();
+      }
+    }
+  }
+
+  /// Returns the current local modules as a list of plain maps. Useful for
+  /// debugging and verifying sync operations.
+  List<Map<String, dynamic>> exportLocalModules() {
+    return _modules.values
+        .map((e) => (e as MarkItem).toMap())
+        .toList(growable: false);
+  }
+
   double get weightedAverageModulesMark {
     double weightedTotal = 0;
     double creditsTotal = 0;

--- a/lib/Screens/dev_test_screen.dart
+++ b/lib/Screens/dev_test_screen.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:provider/provider.dart';
+
+import '../Providers/cloud_provider.dart';
+import '../Providers/module_provider.dart';
+
+class DevTestScreen extends StatefulWidget {
+  static const routeName = '/devTest';
+  const DevTestScreen({super.key});
+
+  @override
+  State<DevTestScreen> createState() => _DevTestScreenState();
+}
+
+class _DevTestScreenState extends State<DevTestScreen> {
+  Box<dynamic>? _box;
+  final TextEditingController _keyController = TextEditingController();
+  final TextEditingController _valueController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _openBox();
+  }
+
+  Future<void> _openBox() async {
+    _box = await Hive.openBox('developer_test');
+    setState(() {});
+  }
+
+  Future<void> _clearDeveloperBox() async {
+    await _box?.clear();
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _keyController.dispose();
+    _valueController.dispose();
+    _box?.close();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_box != null && _keyController.text.isNotEmpty) {
+      await _box!.put(_keyController.text, _valueController.text);
+      _valueController.clear();
+      setState(() {});
+    }
+  }
+
+  Future<void> _delete(String key) async {
+    await _box?.delete(key);
+    setState(() {});
+  }
+
+  void _showModulesDialog(BuildContext context, ModuleProvider modules) {
+    final jsonStr = const JsonEncoder.withIndent('  ')
+        .convert(modules.exportLocalModules());
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Local Modules'),
+        content: SingleChildScrollView(child: Text(jsonStr)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_box == null || !_box!.isOpen) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    final cloud = context.watch<CloudProvider>();
+    final modules = context.watch<ModuleProvider>();
+
+    if (cloud.user == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Developer DB Test')),
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () async {
+              await cloud.signInWithGoogle();
+            },
+            child: const Text('Sign in to use developer tools'),
+          ),
+        ),
+      );
+    }
+
+    final entries = _box!.toMap().entries.toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Developer DB Test'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
+            onPressed: () async {
+              await cloud.signOut();
+            },
+          )
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _keyController,
+                    decoration: const InputDecoration(labelText: 'Key'),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: TextField(
+                    controller: _valueController,
+                    decoration: const InputDecoration(labelText: 'Value'),
+                  ),
+                ),
+                IconButton(
+                  onPressed: _save,
+                  icon: const Icon(Icons.save),
+                )
+              ],
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                ElevatedButton(
+                  onPressed: _clearDeveloperBox,
+                  child: const Text('Clear Dev Box'),
+                ),
+                ElevatedButton(
+                  onPressed: () => modules.clearLocalModules(),
+                  child: const Text('Clear Local Modules'),
+                ),
+                ElevatedButton(
+                  onPressed: () => modules.forceLoadFromCloud(),
+                  child: const Text('Force Download'),
+                ),
+                ElevatedButton(
+                  onPressed: () => modules.forceUploadToCloud(),
+                  child: const Text('Force Upload'),
+                ),
+                ElevatedButton(
+                  onPressed: () => _showModulesDialog(context, modules),
+                  child: const Text('Show Local Modules'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Text('Dev Box Entries:', style: Theme.of(context).textTheme.titleMedium),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: entries.length,
+              itemBuilder: (context, index) {
+                final e = entries[index];
+                return ListTile(
+                  title: Text('${e.key}: ${e.value}'),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () => _delete(e.key as String),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -1,8 +1,10 @@
 import 'dart:io' show Platform;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../Providers/cloud_provider.dart';
+import 'dev_test_screen.dart';
 
 class SettingsScreen extends StatelessWidget {
   static const routeName = '/settings';
@@ -42,6 +44,16 @@ class SettingsScreen extends StatelessWidget {
                 child: const Text('Logout'),
               ),
             ],
+          ),
+        if (!kReleaseMode)
+          Padding(
+            padding: const EdgeInsets.only(top: 20),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed(DevTestScreen.routeName);
+              },
+              child: const Text('Developer DB Test'),
+            ),
           ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:markulator/Screens/contributor_information_screen.dart';
 import 'package:markulator/Screens/module_information_screen.dart';
 import 'package:markulator/Screens/settings_screen.dart';
+import 'package:flutter/foundation.dart';
+import 'Screens/dev_test_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -19,9 +21,7 @@ const syncInfoBox = "SyncInfo";
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   await Hive.initFlutter();
 
   Hive.registerAdapter(MarkItemAdapter());
@@ -36,15 +36,17 @@ void main() async {
   final CloudProvider cloudProvider = CloudProvider();
   await moduleProvider.setCloudProvider(cloudProvider);
 
-  runApp(Markulator(
-    moduleProvider: moduleProvider,
-    cloudProvider: cloudProvider,
-  ));
+  runApp(
+    Markulator(moduleProvider: moduleProvider, cloudProvider: cloudProvider),
+  );
 }
 
 class Markulator extends StatelessWidget {
-  const Markulator(
-      {super.key, required this.moduleProvider, required this.cloudProvider});
+  const Markulator({
+    super.key,
+    required this.moduleProvider,
+    required this.cloudProvider,
+  });
 
   final ModuleProvider moduleProvider;
   final CloudProvider cloudProvider;
@@ -56,18 +58,14 @@ class Markulator extends StatelessWidget {
         ChangeNotifierProvider<SystemInformationProvider>(
           create: (context) => SystemInformationProvider(),
         ),
-        ChangeNotifierProvider<ModuleProvider>(
-          create: (_) => moduleProvider,
-        ),
-        ChangeNotifierProvider<CloudProvider>(
-          create: (_) => cloudProvider,
-        ),
+        ChangeNotifierProvider<ModuleProvider>(create: (_) => moduleProvider),
+        ChangeNotifierProvider<CloudProvider>(create: (_) => cloudProvider),
       ],
       child: MaterialApp(
         title: 'Markulator',
         theme: ThemeData(
-            colorScheme:
-                ColorScheme.fromSwatch(primarySwatch: Colors.blueGrey)),
+          colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.blueGrey),
+        ),
         // theme: ThemeData.light()
         // ThemeData(
         //   colorScheme: const ColorScheme(
@@ -91,6 +89,8 @@ class Markulator extends StatelessWidget {
           ContributorInformationScreen.routeName: ((context) =>
               const ContributorInformationScreen()),
           SettingsScreen.routeName: ((context) => const SettingsScreen()),
+          if (!kReleaseMode)
+            DevTestScreen.routeName: ((context) => const DevTestScreen()),
         },
       ),
     );


### PR DESCRIPTION
## Summary
- create `DevTestScreen` for debugging storage
- expose the screen only in non-release builds
- link to the screen from Settings when in debug mode
- clean up an unused import in `cloud_provider`


------
https://chatgpt.com/codex/tasks/task_e_68429bf4b29083258624d3d9d8bb7aee