### PR TITLE
Unify widget text styles

### DIFF
--- a/lib/Screens/contributor_information_screen.dart
+++ b/lib/Screens/contributor_information_screen.dart
@@ -90,7 +90,10 @@ class _ContributorInformationScreenState
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
-          middle: Text(parent.name),
+          middle: Text(
+            parent.name,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -122,7 +125,7 @@ class _ContributorInformationScreenState
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        title: Text(parent.name),
+        title: Text(parent.name, style: Theme.of(context).textTheme.bodyMedium),
         actions: [
           IconButton(
             icon: const Icon(Icons.edit_rounded),

--- a/lib/Screens/dev_test_screen.dart
+++ b/lib/Screens/dev_test_screen.dart
@@ -57,17 +57,23 @@ class _DevTestScreenState extends State<DevTestScreen> {
   }
 
   void _showModulesDialog(BuildContext context, ModuleProvider modules) {
-    final jsonStr = const JsonEncoder.withIndent('  ')
-        .convert(modules.exportLocalModules());
+    final jsonStr = const JsonEncoder.withIndent(
+      '  ',
+    ).convert(modules.exportLocalModules());
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Local Modules'),
-        content: SingleChildScrollView(child: Text(jsonStr)),
+        title: Text(
+          'Local Modules',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        content: SingleChildScrollView(
+          child: Text(jsonStr, style: Theme.of(context).textTheme.bodyMedium),
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Close'),
+            child: Text('Close', style: Theme.of(context).textTheme.bodyMedium),
           ),
         ],
       ),
@@ -85,13 +91,21 @@ class _DevTestScreenState extends State<DevTestScreen> {
 
     if (cloud.user == null) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Developer DB Test')),
+        appBar: AppBar(
+          title: Text(
+            'Developer DB Test',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
         body: Center(
           child: ElevatedButton(
             onPressed: () async {
               await cloud.signInWithGoogle();
             },
-            child: const Text('Sign in to use developer tools'),
+            child: Text(
+              'Sign in to use developer tools',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
           ),
         ),
       );
@@ -101,7 +115,10 @@ class _DevTestScreenState extends State<DevTestScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Developer DB Test'),
+        title: Text(
+          'Developer DB Test',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),
@@ -109,7 +126,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
             onPressed: () async {
               await cloud.signOut();
             },
-          )
+          ),
         ],
       ),
       body: SingleChildScrollView(
@@ -117,7 +134,10 @@ class _DevTestScreenState extends State<DevTestScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
+            Text(
+              'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
             const SizedBox(height: 20),
             Row(
               children: [
@@ -134,10 +154,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
                     decoration: const InputDecoration(labelText: 'Value'),
                   ),
                 ),
-                IconButton(
-                  onPressed: _save,
-                  icon: const Icon(Icons.save),
-                )
+                IconButton(onPressed: _save, icon: const Icon(Icons.save)),
               ],
             ),
             const SizedBox(height: 10),
@@ -147,28 +164,46 @@ class _DevTestScreenState extends State<DevTestScreen> {
               children: [
                 ElevatedButton(
                   onPressed: _clearDeveloperBox,
-                  child: const Text('Clear Dev Box'),
+                  child: Text(
+                    'Clear Dev Box',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
                 ElevatedButton(
                   onPressed: () => modules.clearLocalModules(),
-                  child: const Text('Clear Local Modules'),
+                  child: Text(
+                    'Clear Local Modules',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
                 ElevatedButton(
                   onPressed: () => modules.forceLoadFromCloud(),
-                  child: const Text('Force Download'),
+                  child: Text(
+                    'Force Download',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
                 ElevatedButton(
                   onPressed: () => modules.forceUploadToCloud(),
-                  child: const Text('Force Upload'),
+                  child: Text(
+                    'Force Upload',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
                 ElevatedButton(
                   onPressed: () => _showModulesDialog(context, modules),
-                  child: const Text('Show Local Modules'),
+                  child: Text(
+                    'Show Local Modules',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 20),
-            Text('Dev Box Entries:', style: Theme.of(context).textTheme.titleMedium),
+            Text(
+              'Dev Box Entries:',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
             ListView.builder(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
@@ -176,7 +211,10 @@ class _DevTestScreenState extends State<DevTestScreen> {
               itemBuilder: (context, index) {
                 final e = entries[index];
                 return ListTile(
-                  title: Text('${e.key}: ${e.value}'),
+                  title: Text(
+                    '${e.key}: ${e.value}',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                   trailing: IconButton(
                     icon: const Icon(Icons.delete),
                     onPressed: () => _delete(e.key as String),

--- a/lib/Screens/module_information_screen.dart
+++ b/lib/Screens/module_information_screen.dart
@@ -64,17 +64,12 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
                     return Padding(
                       key: ValueKey(
                         moduleProvider
-                            .modules[moduleName]!
-                            .contributors[index]
-                            .key,
+                            .modules[moduleName]!.contributors[index].key,
                       ),
                       padding: const EdgeInsets.symmetric(vertical: 6),
                       child: ContributorWidget(
-                        contributor:
-                            (moduleProvider
-                                    .modules[moduleName]!
-                                    .contributors[index])
-                                as MarkItem,
+                        contributor: (moduleProvider.modules[moduleName]!
+                            .contributors[index]) as MarkItem,
                       ),
                     );
                   },
@@ -97,7 +92,10 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
-          middle: Text(moduleProvider.modules[moduleName]!.name),
+          middle: Text(
+            moduleProvider.modules[moduleName]!.name,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -129,7 +127,10 @@ class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        title: Text(moduleProvider.modules[moduleName]!.name),
+        title: Text(
+          moduleProvider.modules[moduleName]!.name,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.edit_rounded),

--- a/lib/Screens/overview_screen.dart
+++ b/lib/Screens/overview_screen.dart
@@ -44,7 +44,10 @@ class OverviewScreen extends StatelessWidget {
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
-          middle: const Text('Markulator'),
+          middle: Text(
+            'Markulator',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
           trailing: CupertinoButton(
             padding: EdgeInsets.zero,
             onPressed: () {
@@ -79,7 +82,10 @@ class OverviewScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
       appBar: AppBar(
-        title: const Text('Markulator'),
+        title: Text(
+          'Markulator',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
@@ -105,7 +111,10 @@ class OverviewScreen extends StatelessWidget {
           );
         },
         icon: const Icon(Icons.add),
-        label: const Text('Add Module'),
+        label: Text(
+          'Add Module',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
       ),
       floatingActionButtonLocation:
           FloatingActionButtonLocation.miniCenterFloat,

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -18,14 +18,22 @@ class SettingsScreen extends StatelessWidget {
 
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
-        navigationBar: const CupertinoNavigationBar(middle: Text('Settings')),
+        navigationBar: CupertinoNavigationBar(
+          middle: Text(
+            'Settings',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
         child: SafeArea(
           child: ListView(
             children: [
               CupertinoListSection.insetGrouped(
                 children: [
                   CupertinoListTile(
-                    title: const Text('Store data in cloud'),
+                    title: Text(
+                      'Store data in cloud',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                     trailing: CupertinoSwitch(
                       value: cloud.cloudEnabled,
                       onChanged: (val) async {
@@ -45,7 +53,10 @@ class SettingsScreen extends StatelessWidget {
                       await modules.syncOnCloudEnabled(context);
                     }
                   },
-                  child: const Text('Sign in with Google'),
+                  child: Text(
+                    'Sign in with Google',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 )
               else
                 Column(
@@ -53,6 +64,7 @@ class SettingsScreen extends StatelessWidget {
                   children: [
                     Text(
                       'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+                      style: Theme.of(context).textTheme.bodyMedium,
                     ),
                     const SizedBox(height: 8),
                     CupertinoButton(
@@ -60,7 +72,10 @@ class SettingsScreen extends StatelessWidget {
                       onPressed: () async {
                         await cloud.signOut();
                       },
-                      child: const Text('Logout'),
+                      child: Text(
+                        'Logout',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ),
                   ],
                 ),
@@ -72,7 +87,10 @@ class SettingsScreen extends StatelessWidget {
                     onPressed: () {
                       Navigator.of(context).pushNamed(DevTestScreen.routeName);
                     },
-                    child: const Text('Developer DB Test'),
+                    child: Text(
+                      'Developer DB Test',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ),
                 ),
             ],
@@ -83,12 +101,17 @@ class SettingsScreen extends StatelessWidget {
 
     // Android (and other) branch: Material design
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(
+        title: Text('Settings', style: Theme.of(context).textTheme.bodyMedium),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
           ListTile(
-            title: const Text('Store data in cloud'),
+            title: Text(
+              'Store data in cloud',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
             trailing: Switch(
               value: cloud.cloudEnabled,
               onChanged: (val) async {
@@ -107,19 +130,28 @@ class SettingsScreen extends StatelessWidget {
                   await modules.syncOnCloudEnabled(context);
                 }
               },
-              child: const Text('Sign in with Google'),
+              child: Text(
+                'Sign in with Google',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
             )
           else
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Logged in as: ${cloud.user!.email ?? cloud.user!.uid}'),
+                Text(
+                  'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () async {
                     await cloud.signOut();
                   },
-                  child: const Text('Logout'),
+                  child: Text(
+                    'Logout',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
                 ),
               ],
             ),
@@ -132,7 +164,10 @@ class SettingsScreen extends StatelessWidget {
                 onPressed: () {
                   Navigator.of(context).pushNamed(DevTestScreen.routeName);
                 },
-                child: const Text('Developer DB Test'),
+                child: Text(
+                  'Developer DB Test',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
               ),
             ),
         ],

--- a/lib/Widgets/contributor_creation_user_input_widget.dart
+++ b/lib/Widgets/contributor_creation_user_input_widget.dart
@@ -43,17 +43,20 @@ class _ContributorCreationUserInputWidgetState
     super.initState();
 
     _nameController = TextEditingController(
-        text: (widget.toEdit != null) ? widget.toEdit!.name : "");
+      text: (widget.toEdit != null) ? widget.toEdit!.name : "",
+    );
 
     _wightController = TextEditingController(
-        text: (widget.toEdit != null)
-            ? ((widget.toEdit!.weight * 100).toStringAsFixed(2))
-            : "");
+      text: (widget.toEdit != null)
+          ? ((widget.toEdit!.weight * 100).toStringAsFixed(2))
+          : "",
+    );
 
     _percentageController = TextEditingController(
-        text: (widget.toEdit != null)
-            ? ((widget.toEdit!.mark * 100).toStringAsFixed(2))
-            : "");
+      text: (widget.toEdit != null)
+          ? ((widget.toEdit!.mark * 100).toStringAsFixed(2))
+          : "",
+    );
 
     checked = Boolean(
       value: (widget.toEdit != null) ? widget.toEdit!.autoWeight : false,
@@ -85,15 +88,19 @@ class _ContributorCreationUserInputWidgetState
         child: ListView(
           children: <Widget>[
             Container(
-                alignment: Alignment.center,
-                child: (widget.toEdit == null)
-                    ? const PaddedListHeadingWidget(
-                        headingName: "Add mark contributor")
-                    : const PaddedListHeadingWidget(
-                        headingName: "Update mark contributor")),
+              alignment: Alignment.center,
+              child: (widget.toEdit == null)
+                  ? const PaddedListHeadingWidget(
+                      headingName: "Add mark contributor",
+                    )
+                  : const PaddedListHeadingWidget(
+                      headingName: "Update mark contributor",
+                    ),
+            ),
             Padding(
-              padding:
-                  EdgeInsets.symmetric(horizontal: widget.screenWidth * 0.1),
+              padding: EdgeInsets.symmetric(
+                horizontal: widget.screenWidth * 0.1,
+              ),
               child: Divider(
                 color: Theme.of(context).colorScheme.secondary,
                 thickness: 1.5,
@@ -104,10 +111,11 @@ class _ContributorCreationUserInputWidgetState
               child: TextField(
                 controller: _nameController,
                 decoration: const InputDecoration(
-                    border: UnderlineInputBorder(),
-                    labelText: 'Contributor name',
-                    contentPadding: EdgeInsets.only(left: 7),
-                    hintText: "Super cool module 01"),
+                  border: UnderlineInputBorder(),
+                  labelText: 'Contributor name',
+                  contentPadding: EdgeInsets.only(left: 7),
+                  hintText: "Super cool module 01",
+                ),
               ),
             ),
             Padding(
@@ -146,11 +154,9 @@ class _ContributorCreationUserInputWidgetState
                 child: ElevatedButton(
                   style: ButtonStyle(
                     alignment: Alignment.center,
-                    padding:
-                        WidgetStateProperty.all(const EdgeInsets.symmetric(
-                      horizontal: 0,
-                      vertical: 20,
-                    )),
+                    padding: WidgetStateProperty.all(
+                      const EdgeInsets.symmetric(horizontal: 0, vertical: 20),
+                    ),
                   ),
                   onPressed: () {
                     if (widget.toEdit == null) {
@@ -169,7 +175,12 @@ class _ContributorCreationUserInputWidgetState
                         autoWeight: checked.wrappedValue,
                       );
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Contributor added')),
+                        SnackBar(
+                          content: Text(
+                            'Contributor added',
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ),
                       );
                     } else {
                       moduleProvider.updateContributor(
@@ -188,22 +199,34 @@ class _ContributorCreationUserInputWidgetState
                         parent: widget.toEdit!.parent!,
                       );
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Contributor updated')),
+                        SnackBar(
+                          content: Text(
+                            'Contributor updated',
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ),
                       );
                     }
 
                     Navigator.of(context).pop();
                   },
                   child: (widget.toEdit == null)
-                      ? const Text("Add")
-                      : const Text("Update"),
+                      ? Text(
+                          "Add",
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        )
+                      : Text(
+                          "Update",
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
                 ),
               ),
             ),
             Padding(
               padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom),
-            )
+                bottom: MediaQuery.of(context).viewInsets.bottom,
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/Widgets/contributor_widget.dart
+++ b/lib/Widgets/contributor_widget.dart
@@ -10,10 +10,7 @@ import './percentage_indicator_widget.dart';
 import 'contributor_creation_user_input_widget.dart';
 
 class ContributorWidget extends StatefulWidget {
-  const ContributorWidget({
-    super.key,
-    required this.contributor,
-  });
+  const ContributorWidget({super.key, required this.contributor});
 
   final MarkItem contributor;
 
@@ -32,7 +29,8 @@ class _ContributorWidgetState extends State<ContributorWidget> {
     provider = Provider.of<ModuleProvider>(context, listen: false);
     systemInformationProvider = Provider.of<SystemInformationProvider>(context);
     screenHeight = systemInformationProvider.androidAvailableScreenHeight(
-        context: context);
+      context: context,
+    );
     super.didChangeDependencies();
   }
 
@@ -45,45 +43,46 @@ class _ContributorWidgetState extends State<ContributorWidget> {
           decoration: BoxDecoration(
             boxShadow: [
               BoxShadow(
-                  color: Colors.blueGrey[300]!,
-                  blurRadius: 2.5,
-                  offset: const Offset(5.0, 7.0)),
+                color: Colors.blueGrey[300]!,
+                blurRadius: 2.5,
+                offset: const Offset(5.0, 7.0),
+              ),
             ],
             borderRadius: BorderRadius.circular(10),
           ),
           child: Card(
             elevation: 1,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
             child: Slidable(
               key: ValueKey(widget.contributor),
               endActionPane: ActionPane(
                 extentRatio: 0.5,
-                motion: DrawerMotion(
-                  key: widget.key,
-                ),
+                motion: DrawerMotion(key: widget.key),
                 children: [
                   SlidableAction(
                     onPressed: (_) {
                       showModalBottomSheet(
-                          isScrollControlled: true,
-                          isDismissible: true,
-                          context: context,
-                          shape: const RoundedRectangleBorder(
-                              borderRadius: BorderRadius.vertical(
+                        isScrollControlled: true,
+                        isDismissible: true,
+                        context: context,
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.vertical(
                             bottom: Radius.zero,
                             top: Radius.circular(14),
-                          )),
-                          builder: (ctx) => Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 30),
-                                child: ContributorCreationUserInputWidget(
-                                  screenHeight: 0,
-                                  screenWidth: MediaQuery.of(ctx).size.width,
-                                  parent: null,
-                                  toEdit: widget.contributor,
-                                ),
-                              ));
+                          ),
+                        ),
+                        builder: (ctx) => Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 30),
+                          child: ContributorCreationUserInputWidget(
+                            screenHeight: 0,
+                            screenWidth: MediaQuery.of(ctx).size.width,
+                            parent: null,
+                            toEdit: widget.contributor,
+                          ),
+                        ),
+                      );
                     },
                     backgroundColor: Theme.of(context).colorScheme.secondary,
                     foregroundColor: Theme.of(context).colorScheme.onPrimary,
@@ -95,20 +94,31 @@ class _ContributorWidgetState extends State<ContributorWidget> {
                       showDialog(
                         context: context,
                         builder: (ctx) => AlertDialog(
-                          title: const Text("Are you sure?"),
-                          content: const Text(
-                              "Do you want to remove this iem with all its sub-contents?"),
+                          title: Text(
+                            "Are you sure?",
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          content: Text(
+                            "Do you want to remove this iem with all its sub-contents?",
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
                           actions: [
                             TextButton.icon(
                               icon: const Icon(Icons.cancel_rounded),
-                              label: const Text("No"),
+                              label: Text(
+                                "No",
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
                               onPressed: () {
                                 Navigator.of(ctx).pop(false);
                               },
                             ),
                             TextButton.icon(
                               icon: const Icon(Icons.check_rounded),
-                              label: const Text("Yes"),
+                              label: Text(
+                                "Yes",
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
                               onPressed: () {
                                 shouldDelete = true;
                                 Navigator.of(ctx).pop(false);
@@ -144,12 +154,14 @@ class _ContributorWidgetState extends State<ContributorWidget> {
                       ? FittedBox(
                           fit: BoxFit.fitWidth,
                           child: Text(
-                              "${(widget.contributor.mark * 100).toStringAsFixed(0)}%"),
+                            "${(widget.contributor.mark * 100).toStringAsFixed(0)}%",
+                          ),
                         )
                       : FittedBox(
                           fit: BoxFit.fitWidth,
                           child: Text(
-                              "${(widget.contributor.mark * 100).toStringAsFixed(2)}%"),
+                            "${(widget.contributor.mark * 100).toStringAsFixed(2)}%",
+                          ),
                         ),
                 ),
                 title: Text(
@@ -163,7 +175,8 @@ class _ContributorWidgetState extends State<ContributorWidget> {
                     if (widget.contributor.contributors.isNotEmpty)
                       (widget.contributor.contributors.length > 1)
                           ? Text(
-                              "${widget.contributor.contributors.length} contributors")
+                              "${widget.contributor.contributors.length} contributors",
+                            )
                           : Text(
                               "${widget.contributor.contributors.length} contributor",
                             ),
@@ -176,9 +189,7 @@ class _ContributorWidgetState extends State<ContributorWidget> {
                             AssetImage('lib/assets/icons/weight.png'),
                             size: 16,
                           ),
-                          const Padding(
-                            padding: EdgeInsets.only(left: 7),
-                          ),
+                          const Padding(padding: EdgeInsets.only(left: 7)),
                           if ((widget.contributor.weight * 100) % 1 != 0)
                             Text(
                               "${(widget.contributor.weight * 100).toStringAsFixed(2)}%",

--- a/lib/Widgets/module_creation_user_input.dart
+++ b/lib/Widgets/module_creation_user_input.dart
@@ -8,10 +8,7 @@ import './padded_list_heading_widget.dart';
 import './percentage_input_widget.dart';
 
 class ModuleCreationUserInputWidget extends StatefulWidget {
-  const ModuleCreationUserInputWidget({
-    super.key,
-    required this.toEdit,
-  });
+  const ModuleCreationUserInputWidget({super.key, required this.toEdit});
 
   final MarkItem? toEdit;
 
@@ -33,17 +30,18 @@ class _ModuleCreationUserInputWidgetState
     super.initState();
 
     _nameController = TextEditingController(
-        text: (widget.toEdit == null) ? "" : widget.toEdit!.name);
+      text: (widget.toEdit == null) ? "" : widget.toEdit!.name,
+    );
 
     _percentageController = TextEditingController(
-        text: (widget.toEdit == null)
-            ? ""
-            : (widget.toEdit!.mark * 100).toStringAsFixed(2));
+      text: (widget.toEdit == null)
+          ? ""
+          : (widget.toEdit!.mark * 100).toStringAsFixed(2),
+    );
 
     _creditsController = TextEditingController(
-        text: (widget.toEdit == null)
-            ? ""
-            : widget.toEdit!.credits.toString());
+      text: (widget.toEdit == null) ? "" : widget.toEdit!.credits.toString(),
+    );
   }
 
   @override
@@ -62,133 +60,152 @@ class _ModuleCreationUserInputWidgetState
         minHeight: 50,
         minWidth: double.infinity,
       ),
-      child: ListView(children: [
-        ModuleCreationHeadingWidget(toEdit: widget.toEdit),
-        Padding(
-          padding: EdgeInsets.symmetric(
-              horizontal: Provider.of<SystemInformationProvider>(context)
-                      .systemInfo
-                      .screenWidth *
-                  0.25),
-          child: Divider(
-              color: Theme.of(context).colorScheme.secondary, thickness: 1.5),
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-            30.0,
-            10.0,
-            30.0,
-            0.0,
-          ),
-          child: TextField(
-            key: const Key("MN"),
-            controller: _nameController,
-            decoration: const InputDecoration(
-              border: UnderlineInputBorder(),
-              labelText: 'Module name',
-              hintText: 'e.g. Calculus',
-              contentPadding: EdgeInsets.only(left: 7),
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(30, 7, 30, 0),
-          child: TextField(
-            key: const Key("MC"),
-            controller: _creditsController,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            decoration: const InputDecoration(
-              border: UnderlineInputBorder(),
-              labelText: 'Credits',
-              contentPadding: EdgeInsets.only(left: 7),
-            ),
-          ),
-        ),
-        if (widget.toEdit == null ||
-            (widget.toEdit != null && widget.toEdit!.contributors.isEmpty))
+      child: ListView(
+        children: [
+          ModuleCreationHeadingWidget(toEdit: widget.toEdit),
           Padding(
-            padding: const EdgeInsets.fromLTRB(30, 7, 0, 0),
-            child: LayoutBuilder(
-              builder: ((context, constraints) {
-                return Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox(
-                      width: constraints.maxWidth * 0.4,
-                      child: PercentageInputWidget(
-                        key: const Key("MI"),
-                        label: "Mark",
-                        readOnly: false,
-                        percentageController: _percentageController,
-                      ),
-                    ),
-                  ],
-                );
-              }),
+            padding: EdgeInsets.symmetric(
+              horizontal: Provider.of<SystemInformationProvider>(
+                    context,
+                  ).systemInfo.screenWidth *
+                  0.25,
+            ),
+            child: Divider(
+              color: Theme.of(context).colorScheme.secondary,
+              thickness: 1.5,
             ),
           ),
-        Padding(
-          padding: EdgeInsets.fromLTRB(
-            screenWidth * 0.25,
-            21,
-            screenWidth * 0.25,
-            7,
-          ),
-          child: SizedBox(
-            width: screenWidth,
-            child: ElevatedButton(
-              style: ButtonStyle(
-                alignment: Alignment.center,
-                padding: WidgetStateProperty.all(const EdgeInsets.symmetric(
-                  horizontal: 0,
-                  vertical: 20,
-                )),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(30.0, 10.0, 30.0, 0.0),
+            child: TextField(
+              key: const Key("MN"),
+              controller: _nameController,
+              decoration: const InputDecoration(
+                border: UnderlineInputBorder(),
+                labelText: 'Module name',
+                hintText: 'e.g. Calculus',
+                contentPadding: EdgeInsets.only(left: 7),
               ),
-              onPressed: () {
-                if (widget.toEdit == null) {
-                  moduleProvider.addModule(
-                    name: _nameController.text,
-                    mark: (double.tryParse(_percentageController.text) != null)
-                        ? double.parse(_percentageController.text)
-                        : 0,
-                    contributors: null,
-                    credits: (double.tryParse(_creditsController.text) != null)
-                        ? double.parse(_creditsController.text)
-                        : 0,
-                  );
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Module added')),
-                  );
-                } else {
-                  moduleProvider.updateModule(
-                    id: widget.toEdit!.key,
-                    name: _nameController.text,
-                    mark: (double.tryParse(_percentageController.text) != null)
-                        ? double.parse(_percentageController.text)
-                        : 0,
-                    credits: (double.tryParse(_creditsController.text) != null)
-                        ? double.parse(_creditsController.text)
-                        : widget.toEdit!.credits,
-                  );
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Module updated')),
-                  );
-                }
-
-                Navigator.of(context).pop();
-              },
-              child: widget.toEdit == null
-                  ? const Text("Add")
-                  : const Text("Update"),
             ),
           ),
-        ),
-        Padding(
-          padding:
-              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-        ),
-      ]),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(30, 7, 30, 0),
+            child: TextField(
+              key: const Key("MC"),
+              controller: _creditsController,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              decoration: const InputDecoration(
+                border: UnderlineInputBorder(),
+                labelText: 'Credits',
+                contentPadding: EdgeInsets.only(left: 7),
+              ),
+            ),
+          ),
+          if (widget.toEdit == null ||
+              (widget.toEdit != null && widget.toEdit!.contributors.isEmpty))
+            Padding(
+              padding: const EdgeInsets.fromLTRB(30, 7, 0, 0),
+              child: LayoutBuilder(
+                builder: ((context, constraints) {
+                  return Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(
+                        width: constraints.maxWidth * 0.4,
+                        child: PercentageInputWidget(
+                          key: const Key("MI"),
+                          label: "Mark",
+                          readOnly: false,
+                          percentageController: _percentageController,
+                        ),
+                      ),
+                    ],
+                  );
+                }),
+              ),
+            ),
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              screenWidth * 0.25,
+              21,
+              screenWidth * 0.25,
+              7,
+            ),
+            child: SizedBox(
+              width: screenWidth,
+              child: ElevatedButton(
+                style: ButtonStyle(
+                  alignment: Alignment.center,
+                  padding: WidgetStateProperty.all(
+                    const EdgeInsets.symmetric(horizontal: 0, vertical: 20),
+                  ),
+                ),
+                onPressed: () {
+                  if (widget.toEdit == null) {
+                    moduleProvider.addModule(
+                      name: _nameController.text,
+                      mark:
+                          (double.tryParse(_percentageController.text) != null)
+                              ? double.parse(_percentageController.text)
+                              : 0,
+                      contributors: null,
+                      credits:
+                          (double.tryParse(_creditsController.text) != null)
+                              ? double.parse(_creditsController.text)
+                              : 0,
+                    );
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          'Module added',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    );
+                  } else {
+                    moduleProvider.updateModule(
+                      id: widget.toEdit!.key,
+                      name: _nameController.text,
+                      mark:
+                          (double.tryParse(_percentageController.text) != null)
+                              ? double.parse(_percentageController.text)
+                              : 0,
+                      credits:
+                          (double.tryParse(_creditsController.text) != null)
+                              ? double.parse(_creditsController.text)
+                              : widget.toEdit!.credits,
+                    );
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          'Module updated',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    );
+                  }
+
+                  Navigator.of(context).pop();
+                },
+                child: widget.toEdit == null
+                    ? Text("Add", style: Theme.of(context).textTheme.bodyMedium)
+                    : Text(
+                        "Update",
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -215,10 +232,7 @@ class _ModuleCreationUserInputWidgetState
 }
 
 class ModuleCreationHeadingWidget extends StatelessWidget {
-  const ModuleCreationHeadingWidget({
-    super.key,
-    required this.toEdit,
-  });
+  const ModuleCreationHeadingWidget({super.key, required this.toEdit});
 
   final MarkItem? toEdit;
 

--- a/lib/Widgets/module_widget.dart
+++ b/lib/Widgets/module_widget.dart
@@ -70,10 +70,9 @@ class _ModuleWidgetState extends State<ModuleWidget> {
                     textAlign: TextAlign.center,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyLarge!
-                        .copyWith(color: Colors.black),
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyLarge!.copyWith(color: Colors.black),
                   ),
                   const SizedBox(height: 4),
                   Row(
@@ -123,8 +122,11 @@ class _ModuleWidgetState extends State<ModuleWidget> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               (moduleProvider.modules[widget.id]!.contributors.isNotEmpty)
-                  ? const Text('Rename')
-                  : const Text('Edit'),
+                  ? Text(
+                      'Rename',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    )
+                  : Text('Edit', style: Theme.of(context).textTheme.bodyMedium),
               const Icon(Icons.edit_rounded),
             ],
           ),
@@ -134,7 +136,7 @@ class _ModuleWidgetState extends State<ModuleWidget> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Text('Remove'),
+              Text('Remove', style: Theme.of(context).textTheme.bodyMedium),
               Icon(
                 Icons.delete_rounded,
                 color: Theme.of(context).colorScheme.error,
@@ -160,8 +162,14 @@ class _ModuleWidgetState extends State<ModuleWidget> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 (moduleProvider.modules[widget.id]!.contributors.isNotEmpty)
-                    ? const Text('Rename')
-                    : const Text('Edit'),
+                    ? Text(
+                        'Rename',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      )
+                    : Text(
+                        'Edit',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                 const Icon(CupertinoIcons.pencil),
               ],
             ),
@@ -174,8 +182,8 @@ class _ModuleWidgetState extends State<ModuleWidget> {
             },
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: const [
-                Text('Remove'),
+              children: [
+                Text('Remove', style: Theme.of(context).textTheme.bodyMedium),
                 Icon(CupertinoIcons.delete_solid),
               ],
             ),
@@ -183,7 +191,7 @@ class _ModuleWidgetState extends State<ModuleWidget> {
         ],
         cancelButton: CupertinoActionSheetAction(
           onPressed: () => Navigator.of(ctx).pop(),
-          child: const Text('Cancel'),
+          child: Text('Cancel', style: Theme.of(context).textTheme.bodyMedium),
         ),
       ),
     );
@@ -220,21 +228,25 @@ class _ModuleWidgetState extends State<ModuleWidget> {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text("Are you sure?"),
+        title: Text(
+          "Are you sure?",
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
         content: Text(
           "Do you want to remove ${moduleProvider.modules[widget.id]!.name} with all its sub-contents?",
+          style: Theme.of(context).textTheme.bodyMedium,
         ),
         actions: [
           TextButton.icon(
             icon: const Icon(Icons.cancel_rounded),
-            label: const Text("No"),
+            label: Text("No", style: Theme.of(context).textTheme.bodyMedium),
             onPressed: () {
               Navigator.of(ctx).pop(false);
             },
           ),
           TextButton.icon(
             icon: const Icon(Icons.check_rounded),
-            label: const Text("Yes"),
+            label: Text("Yes", style: Theme.of(context).textTheme.bodyMedium),
             onPressed: () {
               moduleProvider.removeModule(key: widget.id);
               Navigator.of(ctx).pop(false);

--- a/lib/Widgets/weight_percentage_input.dart
+++ b/lib/Widgets/weight_percentage_input.dart
@@ -45,7 +45,10 @@ class _WeightPercentageInputWidgetState
                 },
               ),
             ),
-            const Text("Auto determine"),
+            Text(
+              "Auto determine",
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
           ],
         );
       }),


### PR DESCRIPTION
## Summary
- apply `textTheme.bodyMedium` for text in various widgets
- update dialogs to align with platform typography
- format code and fetch dependencies

## Testing
- `flutter test` *(fails: Test directory "test" not found)*
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6842bfc657c4832598d7475c46265a86