### PR TITLE
Add dark mode setting synced with Firestore

### DIFF
--- a/lib/Providers/cloud_provider.dart
+++ b/lib/Providers/cloud_provider.dart
@@ -179,4 +179,35 @@ class CloudProvider with ChangeNotifier {
 
     return null;
   }
+
+  // ---------------------------------------------------------------------------
+  // Settings Synchronization
+  // ---------------------------------------------------------------------------
+
+  Future<void> syncSettings(Map<String, dynamic> settings) async {
+    if (!cloudEnabled) return;
+    try {
+      await _firestore
+          .collection('userSettings')
+          .doc(user!.uid)
+          .set(settings, SetOptions(merge: true));
+    } catch (e) {
+      debugPrint('❌ [CloudProvider] Failed to sync settings: $e');
+    }
+  }
+
+  Future<Map<String, dynamic>?> fetchSettings() async {
+    if (!cloudEnabled) return null;
+    try {
+      final doc = await _firestore
+          .collection('userSettings')
+          .doc(user!.uid)
+          .get();
+      if (!doc.exists) return null;
+      return doc.data();
+    } catch (e) {
+      debugPrint('❌ [CloudProvider] Error fetching settings: $e');
+      return null;
+    }
+  }
 }

--- a/lib/Providers/settings_provider.dart
+++ b/lib/Providers/settings_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../main.dart';
+import 'cloud_provider.dart';
+
+class SettingsProvider with ChangeNotifier {
+  final CloudProvider cloudProvider;
+  late final Box _settingsBox;
+  bool _darkMode = false;
+
+  SettingsProvider({required this.cloudProvider}) {
+    _settingsBox = Hive.box(settingsBox);
+    _darkMode = _settingsBox.get('darkMode', defaultValue: false) as bool;
+
+    // Listen for auth or cloud changes to fetch settings from the cloud
+    cloudProvider.addListener(_handleCloudChange);
+  }
+
+  bool get darkMode => _darkMode;
+
+  Future<void> setDarkMode(bool value) async {
+    _darkMode = value;
+    await _settingsBox.put('darkMode', value);
+    notifyListeners();
+    await cloudProvider.syncSettings({'darkMode': value});
+  }
+
+  Future<void> _handleCloudChange() async {
+    if (cloudProvider.user != null && cloudProvider.cloudEnabled) {
+      final data = await cloudProvider.fetchSettings();
+      if (data != null && data['darkMode'] is bool) {
+        final bool newValue = data['darkMode'] as bool;
+        if (newValue != _darkMode) {
+          _darkMode = newValue;
+          await _settingsBox.put('darkMode', newValue);
+          notifyListeners();
+        }
+      }
+    }
+  }
+}

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import '../Providers/cloud_provider.dart';
 import '../Providers/module_provider.dart';
+import '../Providers/settings_provider.dart';
 import 'dev_test_screen.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -15,6 +16,7 @@ class SettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final cloud = Provider.of<CloudProvider>(context);
     final modules = Provider.of<ModuleProvider>(context, listen: false);
+    final settings = Provider.of<SettingsProvider>(context);
 
     if (Platform.isIOS) {
       return CupertinoPageScaffold(
@@ -40,6 +42,16 @@ class SettingsScreen extends StatelessWidget {
                         cloud.setCloudEnabled(val);
                         if (val) await modules.syncOnCloudEnabled(context);
                       },
+                    ),
+                  ),
+                  CupertinoListTile(
+                    title: Text(
+                      'Dark mode',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    trailing: CupertinoSwitch(
+                      value: settings.darkMode,
+                      onChanged: (val) => settings.setDarkMode(val),
                     ),
                   ),
                 ],
@@ -118,6 +130,16 @@ class SettingsScreen extends StatelessWidget {
                 cloud.setCloudEnabled(val);
                 if (val) await modules.syncOnCloudEnabled(context);
               },
+            ),
+          ),
+          ListTile(
+            title: Text(
+              'Dark mode',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            trailing: Switch(
+              value: settings.darkMode,
+              onChanged: (val) => settings.setDarkMode(val),
             ),
           ),
           const SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- add `settingsBox` for Hive and open it at startup
- create `SettingsProvider` with Hive and cloud sync support
- sync settings via new methods in `CloudProvider`
- update `MaterialApp` to use themeMode from SettingsProvider
- include new dark mode switches on the settings screen

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cea6c6d08325b0508ff34246dbb3