### PR TITLE
Improve carousel display

### DIFF
--- a/lib/Widgets/average_percentage_widget.dart
+++ b/lib/Widgets/average_percentage_widget.dart
@@ -12,6 +12,15 @@ class AveragePercentageWidget extends StatelessWidget {
   final double percentage;
   final String heading;
 
+  String _classificationText() {
+    final value = percentage * 100;
+    if (value >= 70) return 'First class';
+    if (value >= 60) return 'Upper second (2:1)';
+    if (value >= 50) return 'Lower second (2:2)';
+    if (value >= 40) return 'Third class';
+    return 'Fail';
+  }
+
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -22,9 +31,10 @@ class AveragePercentageWidget extends StatelessWidget {
             decoration: BoxDecoration(
               boxShadow: [
                 BoxShadow(
-                    color: Colors.blueGrey[300]!,
-                    blurRadius: 2.5,
-                    offset: const Offset(5.0, 7.0)),
+                  color: Colors.blueGrey[300]!,
+                  blurRadius: 2.5,
+                  offset: const Offset(5.0, 7.0),
+                ),
               ],
               borderRadius: BorderRadius.circular(20),
             ),
@@ -33,19 +43,25 @@ class AveragePercentageWidget extends StatelessWidget {
               shadowColor: Theme.of(context).colorScheme.primary,
               elevation: 1,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(21)),
+                borderRadius: BorderRadius.circular(21),
+              ),
               child: GridTile(
                 header: GridTileBar(
                   backgroundColor: Theme.of(context).colorScheme.secondary,
                   title: Text(
                     heading,
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleLarge!
-                        .copyWith(
-                          color:
-                              Theme.of(context).colorScheme.onSecondary,
-                        ),
+                    style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      color: Theme.of(context).colorScheme.onSecondary,
+                    ),
+                  ),
+                ),
+                footer: GridTileBar(
+                  backgroundColor: Theme.of(context).colorScheme.secondary,
+                  title: Text(
+                    _classificationText(),
+                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                      color: Theme.of(context).colorScheme.onSecondary,
+                    ),
                   ),
                 ),
                 child: Padding(

--- a/lib/Widgets/overview_screen_average_carousel_widget.dart
+++ b/lib/Widgets/overview_screen_average_carousel_widget.dart
@@ -38,6 +38,8 @@ class _OverviewScreenAverageCarouselWidgetState
   @override
   Widget build(BuildContext context) {
     final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
+    final bool showBoth =
+        widget.scrollDirection == Axis.vertical && widget.height > 350;
     final List<Widget> indicators = List.generate(
       2,
       (i) => Container(
@@ -84,6 +86,29 @@ class _OverviewScreenAverageCarouselWidgetState
             mainAxisAlignment: MainAxisAlignment.center,
             children: indicators,
           );
+
+    if (showBoth) {
+      return SizedBox(
+        width: double.infinity,
+        height: widget.height,
+        child: Column(
+          children: [
+            Expanded(
+              child: AveragePercentageWidget(
+                percentage: moduleProvider.averageModulesMark,
+                heading: 'Modules average',
+              ),
+            ),
+            Expanded(
+              child: AveragePercentageWidget(
+                percentage: moduleProvider.weightedAverageModulesMark,
+                heading: 'Weighted average',
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     return SizedBox(
       width: double.infinity,


### PR DESCRIPTION
## Summary
- show classification text beneath each average
- when vertical carousel has enough space, display both averages instead of paging

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442ac552d48325be214194419378d0