### PR TITLE
Refactor providers into services

### DIFF
--- a/lib/Providers/settings_provider.dart
+++ b/lib/Providers/settings_provider.dart
@@ -2,19 +2,19 @@ import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../main.dart';
-import 'cloud_provider.dart';
+import '../data/services/cloud_service.dart';
 
 class SettingsProvider with ChangeNotifier {
-  final CloudProvider cloudProvider;
+  final CloudService cloudService;
   late final Box _settingsBox;
   bool _darkMode = false;
 
-  SettingsProvider({required this.cloudProvider}) {
+  SettingsProvider({required this.cloudService}) {
     _settingsBox = Hive.box(settingsBox);
     _darkMode = _settingsBox.get('darkMode', defaultValue: false) as bool;
 
     // Listen for auth or cloud changes to fetch settings from the cloud
-    cloudProvider.addListener(_handleCloudChange);
+    cloudService.addListener(_handleCloudChange);
   }
 
   bool get darkMode => _darkMode;
@@ -23,12 +23,12 @@ class SettingsProvider with ChangeNotifier {
     _darkMode = value;
     await _settingsBox.put('darkMode', value);
     notifyListeners();
-    await cloudProvider.syncSettings({'darkMode': value});
+    await cloudService.syncSettings({'darkMode': value});
   }
 
   Future<void> _handleCloudChange() async {
-    if (cloudProvider.user != null && cloudProvider.cloudEnabled) {
-      final data = await cloudProvider.fetchSettings();
+    if (cloudService.user != null && cloudService.cloudEnabled) {
+      final data = await cloudService.fetchSettings();
       if (data != null && data['darkMode'] is bool) {
         final bool newValue = data['darkMode'] as bool;
         if (newValue != _darkMode) {

--- a/lib/Screens/contributor_information_screen.dart
+++ b/lib/Screens/contributor_information_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../Model/module_model.dart';
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
@@ -23,12 +23,12 @@ class ContributorInformationScreen extends StatefulWidget {
 class _ContributorInformationScreenState
     extends State<ContributorInformationScreen> {
   late MarkItem parent;
-  late ModuleProvider moduleProvider;
+  late ModuleRepository moduleProvider;
 
   @override
   void didChangeDependencies() {
     parent = ModalRoute.of(context)!.settings.arguments as MarkItem;
-    moduleProvider = Provider.of<ModuleProvider>(context);
+    moduleProvider = Provider.of<ModuleRepository>(context);
     super.didChangeDependencies();
   }
 

--- a/lib/Screens/dev_test_screen.dart
+++ b/lib/Screens/dev_test_screen.dart
@@ -3,8 +3,9 @@ import 'dart:convert';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
-import '../Providers/cloud_provider.dart';
-import '../Providers/module_provider.dart';
+import '../data/services/auth_service.dart';
+import '../data/services/cloud_service.dart';
+import '../data/repositories/module_repository.dart';
 
 class DevTestScreen extends StatefulWidget {
   static const routeName = '/devTest';
@@ -56,7 +57,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
     setState(() {});
   }
 
-  void _showModulesDialog(BuildContext context, ModuleProvider modules) {
+  void _showModulesDialog(BuildContext context, ModuleRepository modules) {
     final jsonStr = const JsonEncoder.withIndent(
       '  ',
     ).convert(modules.exportLocalModules());
@@ -86,10 +87,11 @@ class _DevTestScreenState extends State<DevTestScreen> {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
-    final cloud = context.watch<CloudProvider>();
-    final modules = context.watch<ModuleProvider>();
+    final cloud = context.watch<CloudService>();
+    final auth = context.watch<AuthService>();
+    final modules = context.watch<ModuleRepository>();
 
-    if (cloud.user == null) {
+    if (auth.user == null) {
       return Scaffold(
         appBar: AppBar(
           title: Text(
@@ -100,7 +102,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
         body: Center(
           child: ElevatedButton(
             onPressed: () async {
-              await cloud.signInWithGoogle();
+              await auth.signInWithGoogle();
             },
             child: Text(
               'Sign in to use developer tools',
@@ -124,7 +126,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
             icon: const Icon(Icons.logout),
             tooltip: 'Logout',
             onPressed: () async {
-              await cloud.signOut();
+              await auth.signOut();
             },
           ),
         ],
@@ -135,7 +137,7 @@ class _DevTestScreenState extends State<DevTestScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+              'Logged in as: ${auth.user!.email ?? auth.user!.uid}',
               style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 20),

--- a/lib/Screens/module_information_screen.dart
+++ b/lib/Screens/module_information_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../Model/module_model.dart';
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import '../Widgets/add_contributor_pop_up_modal_widget.dart';
 import '../Widgets/average_percentage_widget.dart';
 import '../Widgets/contributor_widget.dart';
@@ -21,13 +21,13 @@ class ModuleInformationScreen extends StatefulWidget {
 }
 
 class _ModuleInformationScreenState extends State<ModuleInformationScreen> {
-  late ModuleProvider moduleProvider;
+  late ModuleRepository moduleProvider;
   late int moduleName;
 
   @override
   void didChangeDependencies() {
     moduleName = ModalRoute.of(context)!.settings.arguments as int;
-    moduleProvider = Provider.of<ModuleProvider>(context);
+    moduleProvider = Provider.of<ModuleRepository>(context);
     super.didChangeDependencies();
   }
 

--- a/lib/Screens/settings_screen.dart
+++ b/lib/Screens/settings_screen.dart
@@ -3,8 +3,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
-import '../Providers/cloud_provider.dart';
-import '../Providers/module_provider.dart';
+import '../data/services/auth_service.dart';
+import '../data/services/cloud_service.dart';
+import '../data/repositories/module_repository.dart';
 import '../Providers/settings_provider.dart';
 import 'dev_test_screen.dart';
 
@@ -14,8 +15,9 @@ class SettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cloud = Provider.of<CloudProvider>(context);
-    final modules = Provider.of<ModuleProvider>(context, listen: false);
+    final cloud = Provider.of<CloudService>(context);
+    final auth = Provider.of<AuthService>(context);
+    final modules = Provider.of<ModuleRepository>(context, listen: false);
     final settings = Provider.of<SettingsProvider>(context);
 
     if (Platform.isIOS) {
@@ -57,10 +59,10 @@ class SettingsScreen extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 16),
-              if (cloud.user == null)
+              if (auth.user == null)
                 CupertinoButton.filled(
                   onPressed: () async {
-                    await cloud.signInWithGoogle();
+                    await auth.signInWithGoogle();
                     if (cloud.cloudEnabled) {
                       await modules.syncOnCloudEnabled(context);
                     }
@@ -75,14 +77,14 @@ class SettingsScreen extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+                      'Logged in as: ${auth.user!.email ?? auth.user!.uid}',
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
                     const SizedBox(height: 8),
                     CupertinoButton(
                       color: CupertinoColors.systemGrey,
                       onPressed: () async {
-                        await cloud.signOut();
+                        await auth.signOut();
                       },
                       child: Text(
                         'Logout',
@@ -144,10 +146,10 @@ class SettingsScreen extends StatelessWidget {
           ),
           const SizedBox(height: 20),
 
-          if (cloud.user == null)
+          if (auth.user == null)
             ElevatedButton(
               onPressed: () async {
-                await cloud.signInWithGoogle();
+                await auth.signInWithGoogle();
                 if (cloud.cloudEnabled) {
                   await modules.syncOnCloudEnabled(context);
                 }
@@ -162,13 +164,13 @@ class SettingsScreen extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Logged in as: ${cloud.user!.email ?? cloud.user!.uid}',
+                  'Logged in as: ${auth.user!.email ?? auth.user!.uid}',
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () async {
-                    await cloud.signOut();
+                    await auth.signOut();
                   },
                   child: Text(
                     'Logout',

--- a/lib/Widgets/contributor_creation_user_input_widget.dart
+++ b/lib/Widgets/contributor_creation_user_input_widget.dart
@@ -4,7 +4,7 @@ import 'package:markulator/Model/module_model.dart';
 import 'package:markulator/Widgets/weight_percentage_input.dart';
 import 'package:provider/provider.dart';
 
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import '../Providers/system_information_provider.dart';
 import './padded_list_heading_widget.dart';
 import 'percentage_input_widget.dart';
@@ -35,7 +35,7 @@ class _ContributorCreationUserInputWidgetState
   late final TextEditingController _percentageController;
   late final Boolean checked;
 
-  late ModuleProvider moduleProvider;
+  late ModuleRepository moduleProvider;
   late SystemInformationProvider systemInformationProvider;
 
   @override
@@ -65,7 +65,7 @@ class _ContributorCreationUserInputWidgetState
 
   @override
   void didChangeDependencies() {
-    moduleProvider = Provider.of<ModuleProvider>(context);
+    moduleProvider = Provider.of<ModuleRepository>(context);
     systemInformationProvider = Provider.of<SystemInformationProvider>(context);
     super.didChangeDependencies();
   }

--- a/lib/Widgets/contributor_widget.dart
+++ b/lib/Widgets/contributor_widget.dart
@@ -4,7 +4,7 @@ import 'package:markulator/Screens/contributor_information_screen.dart';
 import 'package:provider/provider.dart';
 
 import '../Model/module_model.dart';
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import '../Providers/system_information_provider.dart';
 import './percentage_indicator_widget.dart';
 import 'contributor_creation_user_input_widget.dart';
@@ -19,14 +19,14 @@ class ContributorWidget extends StatefulWidget {
 }
 
 class _ContributorWidgetState extends State<ContributorWidget> {
-  late ModuleProvider provider;
+  late ModuleRepository provider;
   late SystemInformationProvider systemInformationProvider;
   late double screenHeight;
   bool shouldDelete = false;
 
   @override
   void didChangeDependencies() {
-    provider = Provider.of<ModuleProvider>(context, listen: false);
+    provider = Provider.of<ModuleRepository>(context, listen: false);
     systemInformationProvider = Provider.of<SystemInformationProvider>(context);
     screenHeight = systemInformationProvider.androidAvailableScreenHeight(
       context: context,

--- a/lib/Widgets/module_creation_user_input.dart
+++ b/lib/Widgets/module_creation_user_input.dart
@@ -3,7 +3,7 @@ import 'package:markulator/Model/module_model.dart';
 import 'package:markulator/Providers/system_information_provider.dart';
 import 'package:provider/provider.dart';
 
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import './padded_list_heading_widget.dart';
 import './percentage_input_widget.dart';
 
@@ -23,7 +23,7 @@ class _ModuleCreationUserInputWidgetState
   late final TextEditingController _percentageController;
   late final TextEditingController _creditsController;
 
-  late ModuleProvider moduleProvider;
+  late ModuleRepository moduleProvider;
 
   @override
   void initState() {
@@ -46,7 +46,7 @@ class _ModuleCreationUserInputWidgetState
 
   @override
   void didChangeDependencies() {
-    moduleProvider = Provider.of<ModuleProvider>(context);
+    moduleProvider = Provider.of<ModuleRepository>(context);
     super.didChangeDependencies();
   }
 

--- a/lib/Widgets/module_widget.dart
+++ b/lib/Widgets/module_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import '../Screens/module_information_screen.dart';
 import 'module_creation_user_input.dart';
 import 'percentage_indicator_widget.dart';
@@ -18,11 +18,11 @@ class ModuleWidget extends StatefulWidget {
 }
 
 class _ModuleWidgetState extends State<ModuleWidget> {
-  late ModuleProvider moduleProvider;
+  late ModuleRepository moduleProvider;
 
   @override
   void didChangeDependencies() {
-    moduleProvider = Provider.of<ModuleProvider>(context);
+    moduleProvider = Provider.of<ModuleRepository>(context);
     super.didChangeDependencies();
   }
 
@@ -81,18 +81,15 @@ class _ModuleWidgetState extends State<ModuleWidget> {
                       const Icon(Icons.school, size: 14),
                       const SizedBox(width: 4),
                       Text(
-                        module.credits
-                            .toStringAsFixed(module.credits % 1 == 0 ? 0 : 1),
+                        module.credits.toStringAsFixed(
+                          module.credits % 1 == 0 ? 0 : 1,
+                        ),
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
                     ],
                   ),
                 ),
-                Positioned(
-                  top: 0,
-                  right: 0,
-                  child: _buildMenuButton(),
-                ),
+                Positioned(top: 0, right: 0, child: _buildMenuButton()),
               ],
             ),
           ),
@@ -227,7 +224,7 @@ class _ModuleWidgetState extends State<ModuleWidget> {
     }
   }
 
-  void confirmDeletion(BuildContext context, ModuleProvider moduleProvider) {
+  void confirmDeletion(BuildContext context, ModuleRepository moduleProvider) {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(

--- a/lib/Widgets/overview_screen_average_carousel_widget.dart
+++ b/lib/Widgets/overview_screen_average_carousel_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import './average_percentage_widget.dart';
 
 class OverviewScreenAverageCarouselWidget extends StatefulWidget {
@@ -37,7 +37,9 @@ class _OverviewScreenAverageCarouselWidgetState
 
   @override
   Widget build(BuildContext context) {
-    final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
+    final ModuleRepository moduleProvider = Provider.of<ModuleRepository>(
+      context,
+    );
     final bool showBoth =
         widget.scrollDirection == Axis.vertical && widget.height > 370;
     final List<Widget> indicators = List.generate(

--- a/lib/Widgets/overview_screen_grid_widget.dart
+++ b/lib/Widgets/overview_screen_grid_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:reorderable_grid_view/reorderable_grid_view.dart';
 
-import '../Providers/module_provider.dart';
+import '../data/repositories/module_repository.dart';
 import './module_widget.dart';
 import 'overview_screen_no_modules_available_widget.dart';
 import 'padded_list_heading_widget.dart';
@@ -17,7 +17,9 @@ class OverviewScreenGridWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ModuleProvider moduleProvider = Provider.of<ModuleProvider>(context);
+    final ModuleRepository moduleProvider = Provider.of<ModuleRepository>(
+      context,
+    );
     return (moduleProvider.modules.isNotEmpty)
         ? LayoutBuilder(
             builder: (ctx, constraints) {

--- a/lib/data/repositories/module_repository.dart
+++ b/lib/data/repositories/module_repository.dart
@@ -1,0 +1,364 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../Model/module_model.dart';
+import '../../main.dart';
+import '../services/module_service.dart';
+
+class ModuleRepository with ChangeNotifier {
+  late final dynamic _storedModules;
+  late final Map<dynamic, dynamic> _modules;
+  late final Box _syncBox;
+  ModuleService? _service;
+
+  ModuleRepository() {
+    _storedModules = Hive.box(userModulesBox);
+    _syncBox = Hive.box(syncInfoBox);
+    _modules = _storedModules.toMap();
+
+    _modules.removeWhere((key, value) => value.parent != null);
+    _modules.forEach((key, value) => setAppropriateParent(value));
+  }
+
+  DateTime? get localLastUpdated =>
+      _syncBox.get('localLastUpdated') as DateTime?;
+
+  void _updateLocalLastUpdated([DateTime? time]) {
+    _syncBox.put('localLastUpdated', time ?? DateTime.now());
+  }
+
+  Map<int, MarkItem> get modules {
+    return {..._modules};
+  }
+
+  double get averageModulesMark {
+    double total = 0;
+    _modules.forEach((key, value) {
+      total += value.mark;
+    });
+    if (total > 0) {
+      total /= _modules.length;
+    }
+    return total;
+  }
+
+  Future<void> setModuleService(ModuleService service) async {
+    _service = service;
+    final data = await service.fetchModulesIfNewer();
+    if (data != null) {
+      await _loadFromRemote(data, service.cloudService.lastUpdated);
+      notifyListeners();
+    }
+  }
+
+  void _sync() {
+    _updateLocalLastUpdated();
+    if (_service != null) {
+      _service!.syncModules(
+        _modules.values.map((e) => (e as MarkItem).toMap()).toList(),
+      );
+    }
+  }
+
+  Future<void> _loadFromRemote(
+    List<Map<String, dynamic>> data, [
+    DateTime? remoteTime,
+  ]) async {
+    _modules.clear();
+    await _storedModules.clear();
+    for (final map in data) {
+      final item = MarkItem.fromMap(map, _storedModules);
+      _modules[item.key] = item;
+    }
+    _updateLocalLastUpdated(remoteTime);
+  }
+
+  Future<void> clearLocalModules() async {
+    _modules.clear();
+    await _storedModules.clear();
+    _updateLocalLastUpdated();
+    notifyListeners();
+  }
+
+  Future<void> forceUploadToCloud() async {
+    if (_service != null) {
+      await _service!.syncModules(
+        _modules.values.map((e) => (e as MarkItem).toMap()).toList(),
+      );
+    }
+  }
+
+  Future<void> forceLoadFromCloud() async {
+    if (_service != null) {
+      final data = await _service!.fetchAllModules(force: true);
+      if (data != null) {
+        await _loadFromRemote(data, _service!.cloudService.lastUpdated);
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<void> syncOnCloudEnabled(BuildContext context) async {
+    if (_service == null) return;
+    final remoteTs = await _service!.fetchRemoteLastUpdated();
+    if (_modules.isEmpty) {
+      if (remoteTs != null) {
+        final data = await _service!.fetchAllModules(force: true);
+        if (data != null) {
+          await _loadFromRemote(data, remoteTs);
+          notifyListeners();
+        }
+      }
+      return;
+    }
+    final localTs = localLastUpdated;
+    if (remoteTs != null && (localTs == null || remoteTs.isAfter(localTs))) {
+      final useCloud = await _showChoiceDialog(context);
+      if (useCloud == true) {
+        final data = await _service!.fetchAllModules(force: true);
+        if (data != null) {
+          await _loadFromRemote(data, remoteTs);
+          notifyListeners();
+        }
+      } else if (useCloud == false) {
+        await forceUploadToCloud();
+      }
+    } else {
+      await forceUploadToCloud();
+    }
+  }
+
+  Future<bool?> _showChoiceDialog(BuildContext context) {
+    if (Theme.of(context).platform == TargetPlatform.iOS) {
+      return showCupertinoDialog<bool>(
+        context: context,
+        builder: (ctx) => CupertinoAlertDialog(
+          title: const Text('Sync Conflict'),
+          content: const Text(
+            'Cloud data differs from local data. Which version do you want to keep?',
+          ),
+          actions: [
+            CupertinoDialogAction(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('Local'),
+            ),
+            CupertinoDialogAction(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('Cloud'),
+            ),
+          ],
+        ),
+      );
+    }
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Sync Conflict'),
+        content: const Text(
+          'Cloud data differs from local data. Which version do you want to keep?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Local'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Cloud'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Map<String, dynamic>> exportLocalModules() {
+    return _modules.values
+        .map((e) => (e as MarkItem).toMap())
+        .toList(growable: false);
+  }
+
+  double get weightedAverageModulesMark {
+    double weightedTotal = 0;
+    double creditsTotal = 0;
+    _modules.forEach((key, value) {
+      weightedTotal += value.mark * value.credits;
+      creditsTotal += value.credits;
+    });
+    if (creditsTotal > 0) {
+      return weightedTotal / creditsTotal;
+    }
+    return 0;
+  }
+
+  double averageMark(int id) {
+    MarkItem? m = _modules[id];
+    return (m != null) ? m.mark : 0;
+  }
+
+  void addContributor({
+    required MarkItem parent,
+    required String contributorName,
+    required double weight,
+    required double mark,
+    required bool autoWeight,
+  }) {
+    MarkItem toAdd = MarkItem(
+      name: contributorName,
+      weight: weight / 100,
+      mark: mark / 100,
+      contributors: HiveList(_storedModules),
+      parent: parent,
+      autoWeight: autoWeight,
+      credits: 0,
+    );
+    _storedModules.add(toAdd);
+    toAdd.save();
+    parent.contributors.add(toAdd);
+    calculateWeights(parent);
+    notifyListeners();
+    parent.save();
+    _sync();
+  }
+
+  void updateContributor({
+    required int key,
+    required MarkItem parent,
+    required String contributorName,
+    required double weight,
+    required double mark,
+    required bool autoWeight,
+  }) {
+    int index = parent.contributors.indexWhere((element) => element.key == key);
+    (parent.contributors[index] as MarkItem).name = contributorName;
+    (parent.contributors[index] as MarkItem).mark = mark /= 100;
+    (parent.contributors[index] as MarkItem).autoWeight = autoWeight;
+    (parent.contributors[index] as MarkItem).weight = weight /= 100;
+    calculateWeights(parent);
+    notifyListeners();
+    parent.contributors[index].save();
+    _sync();
+  }
+
+  void calculateWeights(MarkItem parent) {
+    List<MarkItem> weightedList = [], unweightedList = [];
+    for (var i = 0; i < parent.contributors.length; i++) {
+      MarkItem currentContributor = (parent.contributors[i] as MarkItem);
+      if (!currentContributor.autoWeight) {
+        weightedList.add(currentContributor);
+      } else {
+        unweightedList.add(currentContributor);
+      }
+    }
+    parent.mark = 0;
+    double totalWeight = 0;
+    for (var i = 0; i < weightedList.length; i++) {
+      MarkItem c = weightedList.elementAt(i);
+      totalWeight += (c.weight * 100);
+      parent.mark += (c.mark * 100) * c.weight;
+    }
+    double remainingWeight = (100 - totalWeight) / unweightedList.length;
+    for (var i = 0; i < unweightedList.length; i++) {
+      MarkItem c = unweightedList.elementAt(i);
+      c.weight = max((remainingWeight / 100), 0);
+      c.save();
+      parent.mark += (c.mark * 100) * c.weight;
+    }
+    parent.mark /= 100;
+    parent.save();
+    if (parent.parent != null) {
+      calculateWeights(parent.parent!);
+    }
+  }
+
+  void addModule({
+    required String name,
+    required double mark,
+    required HiveList? contributors,
+    required double credits,
+  }) {
+    MarkItem m = MarkItem(
+      name: name,
+      mark: mark /= 100,
+      contributors:
+          (contributors != null) ? contributors : HiveList(_storedModules),
+      autoWeight: true,
+      parent: null,
+      weight: 0,
+      credits: credits,
+    );
+    _storedModules.add(m);
+    m.save();
+    _modules.putIfAbsent(m.key, () => m);
+    notifyListeners();
+    _sync();
+  }
+
+  void removeContributor({
+    required MarkItem parent,
+    required MarkItem contributor,
+  }) {
+    _storedModules.delete(contributor.key);
+    calculateWeights(parent);
+    notifyListeners();
+    _sync();
+  }
+
+  void removeModule({required int key}) {
+    _modules.remove(key);
+    notifyListeners();
+    _storedModules.delete(key);
+    _sync();
+  }
+
+  void updateModule({
+    required int id,
+    required String name,
+    required double mark,
+    required double credits,
+  }) {
+    _modules[id]!.name = name;
+    if (_modules[id]!.contributors.isEmpty) {
+      _modules[id]!.mark = mark / 100;
+    }
+    _modules[id]!.credits = credits;
+    notifyListeners();
+    _modules[id]!.save();
+    _sync();
+  }
+
+  void setAppropriateParent(MarkItem parent) {
+    parent.contributors.toList().forEach((element) {
+      (element as MarkItem).parent = parent;
+      setAppropriateParent(element);
+    });
+  }
+
+  void reorderModules(int oldIndex, int newIndex) {
+    final entries = _modules.entries.toList();
+    final entry = entries.removeAt(oldIndex);
+    entries.insert(newIndex, entry);
+    _modules
+      ..clear()
+      ..addEntries(entries);
+    notifyListeners();
+    _sync();
+  }
+
+  void reorderContributors({
+    required MarkItem parent,
+    required int oldIndex,
+    required int newIndex,
+  }) {
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+    final item = parent.contributors.removeAt(oldIndex) as MarkItem;
+    parent.contributors.insert(newIndex, item);
+    parent.save();
+    notifyListeners();
+    _sync();
+  }
+}

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class AuthService with ChangeNotifier {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  AuthService() {
+    _auth.authStateChanges().listen((_) => notifyListeners());
+  }
+
+  User? get user => _auth.currentUser;
+
+  Future<void> signInWithGoogle() async {
+    try {
+      if (kIsWeb) {
+        final provider = GoogleAuthProvider();
+        await _auth.signInWithPopup(provider);
+      } else {
+        final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+        if (googleUser == null) {
+          return;
+        }
+        final GoogleSignInAuthentication googleAuth =
+            await googleUser.authentication;
+        final OAuthCredential credential = GoogleAuthProvider.credential(
+          accessToken: googleAuth.accessToken,
+          idToken: googleAuth.idToken,
+        );
+        await _auth.signInWithCredential(credential);
+      }
+    } on FirebaseAuthException catch (e) {
+      debugPrint(
+        '❌ [AuthService] FirebaseAuthException: ${e.code} – ${e.message}',
+      );
+    } catch (e) {
+      debugPrint('❌ [AuthService] Unexpected error during Google sign-in: $e');
+    }
+    notifyListeners();
+  }
+
+  Future<void> signOut() async {
+    try {
+      await _auth.signOut();
+    } catch (e) {
+      debugPrint('❌ [AuthService] Error signing out: $e');
+    }
+    notifyListeners();
+  }
+}

--- a/lib/data/services/cloud_service.dart
+++ b/lib/data/services/cloud_service.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../main.dart';
+
+class CloudService with ChangeNotifier {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  bool _cloudEnabled = false;
+  late final Box _syncBox;
+
+  CloudService() {
+    _syncBox = Hive.box(syncInfoBox);
+    _cloudEnabled = _syncBox.get('cloudEnabled', defaultValue: false) as bool;
+    _auth.authStateChanges().listen((_) => notifyListeners());
+  }
+
+  User? get user => _auth.currentUser;
+  bool get cloudEnabled => _cloudEnabled && (user != null);
+  DateTime? get lastUpdated => _syncBox.get('lastUpdated') as DateTime?;
+
+  void _updateLastUpdated(DateTime time) {
+    _syncBox.put('lastUpdated', time);
+  }
+
+  void setCloudEnabled(bool value) {
+    _cloudEnabled = value;
+    _syncBox.put('cloudEnabled', value);
+    notifyListeners();
+  }
+
+  Future<DateTime?> fetchRemoteLastUpdated() async {
+    if (user == null) return null;
+    try {
+      final doc =
+          await _firestore.collection('userModules').doc(user!.uid).get();
+      if (!doc.exists) return null;
+      return (doc.data()?['lastUpdated'] as Timestamp?)?.toDate();
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching remote timestamp: $e');
+      return null;
+    }
+  }
+
+  Future<void> syncModules(List<Map<String, dynamic>> modules) async {
+    if (!cloudEnabled) return;
+    final now = DateTime.now();
+    try {
+      await _firestore.collection('userModules').doc(user!.uid).set({
+        'modules': modules,
+        'lastUpdated': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+      _updateLastUpdated(now);
+    } catch (e) {
+      debugPrint('❌ [CloudService] Failed to sync modules: $e');
+    }
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchModulesIfNewer() async {
+    if (!cloudEnabled) return null;
+    try {
+      final doc =
+          await _firestore.collection('userModules').doc(user!.uid).get();
+      if (!doc.exists) return null;
+      final data = doc.data()!;
+      final remoteTs = (data['lastUpdated'] as Timestamp?)?.toDate();
+      if (remoteTs != null &&
+          (lastUpdated == null || remoteTs.isAfter(lastUpdated!))) {
+        _updateLastUpdated(remoteTs);
+        return List<Map<String, dynamic>>.from(data['modules'] as List);
+      }
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching modules: $e');
+    }
+    return null;
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchAllModules({
+    bool force = false,
+  }) async {
+    if (!force && !cloudEnabled) return null;
+    if (user == null) return null;
+    try {
+      final doc =
+          await _firestore.collection('userModules').doc(user!.uid).get();
+      if (!doc.exists) return null;
+      final data = doc.data()!;
+      final remoteTs = (data['lastUpdated'] as Timestamp?)?.toDate();
+      if (remoteTs != null) {
+        _updateLastUpdated(remoteTs);
+      }
+      return List<Map<String, dynamic>>.from(data['modules'] as List);
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching all modules: $e');
+    }
+    return null;
+  }
+
+  Future<void> syncSettings(Map<String, dynamic> settings) async {
+    if (!cloudEnabled) return;
+    try {
+      await _firestore
+          .collection('userSettings')
+          .doc(user!.uid)
+          .set(settings, SetOptions(merge: true));
+    } catch (e) {
+      debugPrint('❌ [CloudService] Failed to sync settings: $e');
+    }
+  }
+
+  Future<Map<String, dynamic>?> fetchSettings() async {
+    if (!cloudEnabled) return null;
+    try {
+      final doc =
+          await _firestore.collection('userSettings').doc(user!.uid).get();
+      if (!doc.exists) return null;
+      return doc.data();
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching settings: $e');
+      return null;
+    }
+  }
+}

--- a/lib/data/services/module_service.dart
+++ b/lib/data/services/module_service.dart
@@ -1,0 +1,23 @@
+import 'cloud_service.dart';
+
+class ModuleService {
+  final CloudService cloudService;
+
+  ModuleService({required this.cloudService});
+
+  Future<void> syncModules(List<Map<String, dynamic>> modules) async {
+    await cloudService.syncModules(modules);
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchModulesIfNewer() async {
+    return cloudService.fetchModulesIfNewer();
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchAllModules({bool force = false}) {
+    return cloudService.fetchAllModules(force: force);
+  }
+
+  Future<DateTime?> fetchRemoteLastUpdated() {
+    return cloudService.fetchRemoteLastUpdated();
+  }
+}


### PR DESCRIPTION
## Summary
- create `auth_service`, `cloud_service`, `module_service`
- add `module_repository` for local storage
- update settings provider to use new services
- adjust UI widgets and screens for new classes
- wire services together in `main.dart`

## Testing
- `dart format lib`
- `flutter analyze` *(fails: 8 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68444e2140b4832580da32abecaf6373