### PR TITLE
Add degree models and integrate with modules

### DIFF
--- a/lib/data/repositories/module_repository.dart
+++ b/lib/data/repositories/module_repository.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../models/module_model.dart';
+import '../../models/degree_year_model.dart';
 import '../../main.dart';
 import '../services/module_service.dart';
 import '../../domain/calculate_contributor_weights.dart';
@@ -250,6 +251,7 @@ class ModuleRepository with ChangeNotifier {
     required double mark,
     required HiveList? contributors,
     required double credits,
+    DegreeYear? year,
   }) {
     MarkItem m = MarkItem(
       name: name,
@@ -265,6 +267,10 @@ class ModuleRepository with ChangeNotifier {
     _storedModules.add(m);
     m.save();
     _modules.putIfAbsent(m.key, () => m);
+    if (year != null) {
+      year.modules.add(m);
+      year.save();
+    }
     notifyListeners();
     _sync();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,8 @@ import './data/services/module_service.dart';
 import './data/repositories/module_repository.dart';
 
 import './models/module_model.dart';
+import './models/degree_year_model.dart';
+import './models/degree_model.dart';
 import './views/overview_screen.dart';
 import './data/services/system_information_service.dart';
 import './data/repositories/settings_repository.dart';
@@ -26,6 +28,8 @@ const userModulesBox = "UserModules";
 const moduleContributorsBox = "ModuleContributors";
 const syncInfoBox = "SyncInfo";
 const settingsBox = "Settings";
+const degreesBox = "Degrees";
+const degreeYearsBox = "DegreeYears";
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -33,11 +37,15 @@ void main() async {
   await Hive.initFlutter();
 
   Hive.registerAdapter(MarkItemAdapter());
+  Hive.registerAdapter(DegreeYearAdapter());
+  Hive.registerAdapter(DegreeAdapter());
 
   await Hive.openBox(
     userModulesBox,
     compactionStrategy: (entries, deletedEntries) => deletedEntries > 20,
   );
+  await Hive.openBox(degreeYearsBox);
+  await Hive.openBox(degreesBox);
   await Hive.openBox(syncInfoBox);
   await Hive.openBox(settingsBox);
 

--- a/lib/models/degree_model.dart
+++ b/lib/models/degree_model.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import 'degree_year_model.dart';
+
+part 'degree_model.g.dart';
+
+@HiveType(typeId: 2)
+class Degree extends HiveObject {
+  @HiveField(1)
+  final String id = UniqueKey().toString();
+
+  @HiveField(2)
+  String name;
+
+  @HiveField(3)
+  HiveList<DegreeYear> years;
+
+  Degree({
+    required this.name,
+    required this.years,
+  });
+}

--- a/lib/models/degree_model.g.dart
+++ b/lib/models/degree_model.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'degree_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class DegreeAdapter extends TypeAdapter<Degree> {
+  @override
+  final int typeId = 2;
+
+  @override
+  Degree read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Degree(
+      name: fields[2] as String,
+      years: (fields[3] as HiveList).castHiveList(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Degree obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(1)
+      ..write(obj.id)
+      ..writeByte(2)
+      ..write(obj.name)
+      ..writeByte(3)
+      ..write(obj.years);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DegreeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/models/degree_year_model.dart
+++ b/lib/models/degree_year_model.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import 'module_model.dart';
+
+part 'degree_year_model.g.dart';
+
+@HiveType(typeId: 1)
+class DegreeYear extends HiveObject {
+  @HiveField(1)
+  final String id = UniqueKey().toString();
+
+  @HiveField(2)
+  int yearIndex;
+
+  @HiveField(3)
+  HiveList<MarkItem> modules;
+
+  DegreeYear({
+    required this.yearIndex,
+    required this.modules,
+  });
+}

--- a/lib/models/degree_year_model.g.dart
+++ b/lib/models/degree_year_model.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'degree_year_model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class DegreeYearAdapter extends TypeAdapter<DegreeYear> {
+  @override
+  final int typeId = 1;
+
+  @override
+  DegreeYear read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return DegreeYear(
+      yearIndex: fields[2] as int,
+      modules: (fields[3] as HiveList).castHiveList(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, DegreeYear obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(1)
+      ..write(obj.id)
+      ..writeByte(2)
+      ..write(obj.yearIndex)
+      ..writeByte(3)
+      ..write(obj.modules);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DegreeYearAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}


### PR DESCRIPTION
## Summary
- add `Degree` and `DegreeYear` Hive models
- register adapters and open boxes for degrees and years
- allow modules to be associated with a `DegreeYear`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6844727a62c883258c7c24fc799c7a63