### PR TITLE
Implement DegreeRepository

### DIFF
--- a/lib/data/repositories/degree_repository.dart
+++ b/lib/data/repositories/degree_repository.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../main.dart';
+import '../../models/degree_model.dart';
+import '../../models/degree_year_model.dart';
+import '../../models/module_model.dart';
+import 'module_repository.dart';
+
+/// Repository managing [Degree] and [DegreeYear] persistence.
+class DegreeRepository with ChangeNotifier {
+  final ModuleRepository moduleRepository;
+  late final Box _degreeBox;
+  late final Box _yearBox;
+  final Map<dynamic, Degree> _degrees = {};
+
+  DegreeRepository({required this.moduleRepository}) {
+    _degreeBox = Hive.box(degreesBox);
+    _yearBox = Hive.box(degreeYearsBox);
+    _degrees.addAll(_degreeBox.toMap().cast<dynamic, Degree>());
+  }
+
+  /// Map of stored degrees keyed by Hive id.
+  Map<dynamic, Degree> get degrees => {..._degrees};
+
+  /// Create a new degree and return its Hive key.
+  int addDegree(String name) {
+    final degree = Degree(name: name, years: HiveList(_yearBox));
+    _degreeBox.add(degree);
+    degree.save();
+    _degrees[degree.key] = degree;
+    notifyListeners();
+    return degree.key as int;
+  }
+
+  /// Remove a degree and all of its years and modules.
+  void removeDegree(int degreeId) {
+    final degree = _degrees[degreeId];
+    if (degree == null) return;
+    for (final year in List<DegreeYear>.from(degree.years)) {
+      removeYear(degreeId, year.key as int);
+    }
+    _degrees.remove(degreeId);
+    _degreeBox.delete(degreeId);
+    notifyListeners();
+  }
+
+  /// Add a year to the given degree and return its Hive key.
+  int addYear(int degreeId, {int? yearIndex}) {
+    final degree = _degrees[degreeId];
+    if (degree == null) throw ArgumentError('Degree not found');
+    final index = yearIndex ?? degree.years.length + 1;
+    final year = DegreeYear(
+      yearIndex: index,
+      modules: HiveList(Hive.box(userModulesBox)),
+    );
+    _yearBox.add(year);
+    year.save();
+    degree.years.add(year);
+    degree.save();
+    notifyListeners();
+    return year.key as int;
+  }
+
+  /// Remove the specified year and all of its modules.
+  void removeYear(int degreeId, int yearId) {
+    final degree = _degrees[degreeId];
+    if (degree == null) return;
+    final year = degree.years.cast<DegreeYear?>().firstWhere(
+          (y) => y?.key == yearId,
+          orElse: () => null,
+        );
+    if (year == null) return;
+
+    // remove modules belonging to year
+    for (final m in List<MarkItem>.from(year.modules)) {
+      moduleRepository.removeModule(key: m.key as int);
+    }
+
+    degree.years.remove(year);
+    degree.save();
+    _yearBox.delete(yearId);
+    notifyListeners();
+  }
+
+  /// Add a module to a year within the given degree.
+  void addModule(
+    int degreeId,
+    int yearId, {
+    required String name,
+    required double mark,
+    required double credits,
+    HiveList? contributors,
+  }) {
+    final degree = _degrees[degreeId];
+    if (degree == null) throw ArgumentError('Degree not found');
+    final year = degree.years.cast<DegreeYear?>().firstWhere(
+          (y) => y?.key == yearId,
+          orElse: () => null,
+        );
+    if (year == null) throw ArgumentError('Year not found');
+    moduleRepository.addModule(
+      name: name,
+      mark: mark,
+      contributors: contributors,
+      credits: credits,
+      year: year,
+    );
+    notifyListeners();
+  }
+
+  /// Average mark of all modules in a year.
+  double averageForYear(int yearId) {
+    final year = _yearBox.get(yearId);
+    if (year == null) return 0;
+    if (year.modules.isEmpty) return 0;
+    double total = 0;
+    for (final m in year.modules.cast<MarkItem>()) {
+      total += m.mark;
+    }
+    return total / year.modules.length;
+  }
+
+  /// Weighted average mark of a year based on credits.
+  double weightedAverageForYear(int yearId) {
+    final year = _yearBox.get(yearId);
+    if (year == null) return 0;
+    double weightedTotal = 0;
+    double creditTotal = 0;
+    for (final m in year.modules.cast<MarkItem>()) {
+      weightedTotal += m.mark * m.credits;
+      creditTotal += m.credits;
+    }
+    return creditTotal > 0 ? weightedTotal / creditTotal : 0;
+  }
+
+  /// Average mark across all years of a degree.
+  double averageForDegree(int degreeId) {
+    final degree = _degrees[degreeId];
+    if (degree == null) return 0;
+    final modules = degree.years
+        .expand((y) => y.modules.cast<MarkItem>())
+        .toList(growable: false);
+    if (modules.isEmpty) return 0;
+    final total = modules.fold<double>(0, (prev, m) => prev + m.mark);
+    return total / modules.length;
+  }
+
+  /// Weighted average across all years of a degree.
+  double weightedAverageForDegree(int degreeId) {
+    final degree = _degrees[degreeId];
+    if (degree == null) return 0;
+    double weighted = 0;
+    double credits = 0;
+    for (final m in degree.years.expand((y) => y.modules.cast<MarkItem>())) {
+      weighted += m.mark * m.credits;
+      credits += m.credits;
+    }
+    return credits > 0 ? weighted / credits : 0;
+  }
+}

--- a/test/degree_repository_test.dart
+++ b/test/degree_repository_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive_test/hive_test.dart';
+
+import 'package:markulator/data/repositories/module_repository.dart';
+import 'package:markulator/data/repositories/degree_repository.dart';
+import 'package:markulator/models/module_model.dart';
+import 'package:markulator/models/degree_model.dart';
+import 'package:markulator/models/degree_year_model.dart';
+import 'package:markulator/main.dart';
+
+void main() {
+  setUp(() async {
+    await setUpTestHive();
+    Hive.registerAdapter(MarkItemAdapter());
+    Hive.registerAdapter(DegreeYearAdapter());
+    Hive.registerAdapter(DegreeAdapter());
+    await Hive.openBox(userModulesBox);
+    await Hive.openBox(degreeYearsBox);
+    await Hive.openBox(degreesBox);
+    await Hive.openBox(syncInfoBox);
+  });
+
+  tearDown(() async {
+    await tearDownTestHive();
+  });
+
+  test('degree and year management with averages', () {
+    final moduleRepo = ModuleRepository();
+    final degreeRepo = DegreeRepository(moduleRepository: moduleRepo);
+
+    final degId = degreeRepo.addDegree('CS');
+    final yearId = degreeRepo.addYear(degId);
+
+    degreeRepo.addModule(
+      degId,
+      yearId,
+      name: 'A',
+      mark: 80,
+      credits: 5,
+      contributors: null,
+    );
+    degreeRepo.addModule(
+      degId,
+      yearId,
+      name: 'B',
+      mark: 60,
+      credits: 10,
+      contributors: null,
+    );
+
+    expect(degreeRepo.degrees.length, 1);
+    expect(moduleRepo.modules.length, 2);
+
+    expect(degreeRepo.averageForYear(yearId), closeTo(0.7, 0.0001));
+    final expectedWeighted = ((0.8 * 5) + (0.6 * 10)) / 15;
+    expect(
+      degreeRepo.weightedAverageForYear(yearId),
+      closeTo(expectedWeighted, 0.0001),
+    );
+    expect(degreeRepo.averageForDegree(degId), closeTo(0.7, 0.0001));
+    expect(
+      degreeRepo.weightedAverageForDegree(degId),
+      closeTo(expectedWeighted, 0.0001),
+    );
+
+    degreeRepo.removeYear(degId, yearId);
+    expect(degreeRepo.degrees[degId]!.years.isEmpty, true);
+    expect(moduleRepo.modules.isEmpty, true);
+
+    final y2 = degreeRepo.addYear(degId);
+    degreeRepo.addModule(
+      degId,
+      y2,
+      name: 'C',
+      mark: 90,
+      credits: 5,
+      contributors: null,
+    );
+    degreeRepo.removeDegree(degId);
+    expect(degreeRepo.degrees.isEmpty, true);
+    expect(moduleRepo.modules.isEmpty, true);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `DegreeRepository` to manage degrees, years, and statistics
- add unit tests for new repository

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68447753fbac8325a196f3b8c88cd129