### PR TITLE
Add degree overview and information screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:markulator/views/contributor_information_screen.dart';
 import 'package:markulator/views/module_information_screen.dart';
+import 'package:markulator/views/degree_overview_screen.dart';
+import 'package:markulator/views/degree_information_screen.dart';
 import 'package:markulator/views/settings_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'views/dev_test_screen.dart';
@@ -12,11 +14,11 @@ import './data/services/auth_service.dart';
 import './data/services/cloud_service.dart';
 import './data/services/module_service.dart';
 import './data/repositories/module_repository.dart';
+import './data/repositories/degree_repository.dart';
 
 import './models/module_model.dart';
 import './models/degree_year_model.dart';
 import './models/degree_model.dart';
-import './views/overview_screen.dart';
 import './data/services/system_information_service.dart';
 import './data/repositories/settings_repository.dart';
 import './view_models/overview_view_model.dart';
@@ -52,6 +54,9 @@ void main() async {
   // Instantiate repositories and services first so they can be passed to
   // the view models below.
   final ModuleRepository moduleRepository = ModuleRepository();
+  final DegreeRepository degreeRepository = DegreeRepository(
+    moduleRepository: moduleRepository,
+  );
   final AuthService authService = AuthService();
   final CloudService cloudService = CloudService();
 
@@ -68,6 +73,7 @@ void main() async {
   runApp(
     Markulator(
       moduleRepository: moduleRepository,
+      degreeRepository: degreeRepository,
       cloudService: cloudService,
       authService: authService,
       settingsRepository: settingsRepository,
@@ -80,6 +86,7 @@ class Markulator extends StatelessWidget {
   const Markulator({
     super.key,
     required this.moduleRepository,
+    required this.degreeRepository,
     required this.cloudService,
     required this.authService,
     required this.settingsRepository,
@@ -87,6 +94,7 @@ class Markulator extends StatelessWidget {
   });
 
   final ModuleRepository moduleRepository;
+  final DegreeRepository degreeRepository;
   final CloudService cloudService;
   final AuthService authService;
   final SettingsRepository settingsRepository;
@@ -100,6 +108,7 @@ class Markulator extends StatelessWidget {
           value: systemInfoProvider,
         ),
         ChangeNotifierProvider<ModuleRepository>.value(value: moduleRepository),
+        ChangeNotifierProvider<DegreeRepository>.value(value: degreeRepository),
         ChangeNotifierProvider<CloudService>.value(value: cloudService),
         ChangeNotifierProvider<AuthService>.value(value: authService),
         ChangeNotifierProvider<SettingsRepository>.value(
@@ -142,8 +151,12 @@ class Markulator extends StatelessWidget {
             visualDensity: VisualDensity.adaptivePlatformDensity,
           ),
           themeMode: settings.darkMode ? ThemeMode.dark : ThemeMode.light,
-          home: const OverviewScreen(),
+          home: const DegreeOverviewScreen(),
           routes: {
+            DegreeOverviewScreen.routeName: ((context) =>
+                const DegreeOverviewScreen()),
+            DegreeInformationScreen.routeName: ((context) =>
+                const DegreeInformationScreen()),
             ModuleInformationScreen.routeName: ((context) =>
                 const ModuleInformationScreen()),
             ContributorInformationScreen.routeName: ((context) =>

--- a/lib/views/degree_information_screen.dart
+++ b/lib/views/degree_information_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../data/repositories/degree_repository.dart';
+import '../models/degree_year_model.dart';
+import '../models/module_model.dart';
+import 'widgets/average_percentage_widget.dart';
+import 'widgets/module_widget.dart';
+
+class DegreeInformationScreen extends StatelessWidget {
+  static const routeName = '/degreeInformation';
+  const DegreeInformationScreen({super.key});
+
+  int _getCrossAxisCount(double width) {
+    final count = (width / 160).floor();
+    return count > 0 ? count : 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = context.watch<DegreeRepository>();
+    final int degreeId = ModalRoute.of(context)!.settings.arguments as int;
+    final degree = repo.degrees[degreeId]!;
+
+    final List<Widget> yearWidgets = degree.years.cast<DegreeYear>().map((
+      year,
+    ) {
+      final modules = year.modules.cast<MarkItem>();
+      final modulesGrid = modules.isEmpty
+          ? Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(
+                'No modules for year ${year.yearIndex}.',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: GridView.builder(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: modules.length,
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: _getCrossAxisCount(
+                    MediaQuery.of(context).size.width,
+                  ),
+                  childAspectRatio: 0.8,
+                  crossAxisSpacing: 14,
+                  mainAxisSpacing: 20,
+                ),
+                itemBuilder: (ctx, idx) {
+                  final m = modules.elementAt(idx);
+                  return ModuleWidget(id: m.key as int);
+                },
+              ),
+            );
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AveragePercentageWidget(
+            percentage: repo.weightedAverageForYear(year.key as int),
+            heading: 'Year ${year.yearIndex} average',
+          ),
+          modulesGrid,
+        ],
+      );
+    }).toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(degree.name, style: Theme.of(context).textTheme.bodyMedium),
+      ),
+      body: ListView(
+        children: [
+          AveragePercentageWidget(
+            percentage: repo.weightedAverageForDegree(degreeId),
+            heading: '${degree.name} average',
+          ),
+          const SizedBox(height: 12),
+          ...yearWidgets,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/degree_overview_screen.dart
+++ b/lib/views/degree_overview_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../data/repositories/degree_repository.dart';
+import 'degree_information_screen.dart';
+import 'widgets/average_percentage_widget.dart';
+
+class DegreeOverviewScreen extends StatelessWidget {
+  static const routeName = '/degrees';
+  const DegreeOverviewScreen({super.key});
+
+  int _getCrossAxisCount(double width) {
+    final count = (width / 160).floor();
+    return count > 0 ? count : 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = context.watch<DegreeRepository>();
+    final degrees = repo.degrees.entries.toList();
+
+    final carouselHeight = MediaQuery.of(context).size.height * 0.3;
+
+    final carousel = degrees.isEmpty
+        ? const SizedBox.shrink()
+        : SizedBox(
+            width: double.infinity,
+            height: carouselHeight,
+            child: PageView(
+              children: degrees
+                  .map(
+                    (e) => AveragePercentageWidget(
+                      percentage: repo.weightedAverageForDegree(e.key as int),
+                      heading: '${e.value.name} average',
+                    ),
+                  )
+                  .toList(),
+            ),
+          );
+
+    final grid = degrees.isEmpty
+        ? Center(
+            child: Text(
+              'No degrees available.',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          )
+        : GridView.builder(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: _getCrossAxisCount(
+                MediaQuery.of(context).size.width,
+              ),
+              childAspectRatio: 1,
+              crossAxisSpacing: 14,
+              mainAxisSpacing: 14,
+            ),
+            itemCount: degrees.length,
+            itemBuilder: (ctx, i) {
+              final entry = degrees[i];
+              return GestureDetector(
+                onTap: () {
+                  Navigator.of(context).pushNamed(
+                    DegreeInformationScreen.routeName,
+                    arguments: entry.key,
+                  );
+                },
+                child: Card(
+                  elevation: 2,
+                  child: Center(
+                    child: Text(
+                      entry.value.name,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Degrees', style: Theme.of(context).textTheme.bodyMedium),
+      ),
+      body: Column(
+        children: [
+          if (degrees.isNotEmpty) carousel,
+          Expanded(
+            child: Padding(padding: const EdgeInsets.all(8), child: grid),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show degrees with averages
- view detailed statistics for a single degree
- wire up degree repository and new screens in `main.dart`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68447a46a0348325a3f70842aef863e9