### PR TITLE
Add degree view models

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,8 @@ import './data/services/system_information_service.dart';
 import './data/repositories/settings_repository.dart';
 import './view_models/overview_view_model.dart';
 import './view_models/module_info_view_model.dart';
+import './view_models/degree_overview_view_model.dart';
+import './view_models/degree_info_view_model.dart';
 import './view_models/contributor_info_view_model.dart';
 import './view_models/settings_view_model.dart';
 
@@ -122,6 +124,14 @@ class Markulator extends StatelessWidget {
         ),
         ChangeNotifierProvider<ModuleInfoViewModel>(
           create: (_) => ModuleInfoViewModel(repository: moduleRepository),
+        ),
+        ChangeNotifierProvider<DegreeOverviewViewModel>(
+          create: (_) => DegreeOverviewViewModel(
+            repository: degreeRepository,
+          ),
+        ),
+        ChangeNotifierProvider<DegreeInfoViewModel>(
+          create: (_) => DegreeInfoViewModel(repository: degreeRepository),
         ),
         ChangeNotifierProvider<ContributorInfoViewModel>(
           create: (_) => ContributorInfoViewModel(repository: moduleRepository),

--- a/lib/view_models/degree_info_view_model.dart
+++ b/lib/view_models/degree_info_view_model.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/repositories/degree_repository.dart';
+import '../models/degree_model.dart';
+import '../models/degree_year_model.dart';
+import '../models/module_model.dart';
+
+class DegreeInfoViewModel with ChangeNotifier {
+  final DegreeRepository repository;
+  int? degreeId;
+
+  DegreeInfoViewModel({required this.repository});
+
+  void setDegree(int id) {
+    if (degreeId != id) {
+      degreeId = id;
+      notifyListeners();
+    }
+  }
+
+  Degree? get degree =>
+      (degreeId != null) ? repository.degrees[degreeId] : null;
+
+  List<DegreeYear> get years =>
+      degree?.years.cast<DegreeYear>().toList(growable: false) ?? const [];
+
+  List<MarkItem> modulesForYear(int yearId) {
+    final year = degree?.years.cast<DegreeYear?>().firstWhere(
+          (y) => y?.key == yearId,
+          orElse: () => null,
+        );
+    return year?.modules.cast<MarkItem>().toList(growable: false) ?? const [];
+  }
+
+  double averageForYear(int yearId) => repository.averageForYear(yearId);
+
+  double weightedAverageForYear(int yearId) =>
+      repository.weightedAverageForYear(yearId);
+
+  double get averageForDegree =>
+      (degreeId != null) ? repository.averageForDegree(degreeId!) : 0;
+
+  double get weightedAverageForDegree =>
+      (degreeId != null) ? repository.weightedAverageForDegree(degreeId!) : 0;
+}

--- a/lib/view_models/degree_overview_view_model.dart
+++ b/lib/view_models/degree_overview_view_model.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/repositories/degree_repository.dart';
+import '../models/degree_model.dart';
+
+class DegreeOverviewViewModel with ChangeNotifier {
+  final DegreeRepository repository;
+
+  DegreeOverviewViewModel({required this.repository});
+
+  Map<dynamic, Degree> get degrees => repository.degrees;
+
+  double averageForDegree(int degreeId) =>
+      repository.averageForDegree(degreeId);
+
+  double weightedAverageForDegree(int degreeId) =>
+      repository.weightedAverageForDegree(degreeId);
+}

--- a/test/degree_info_view_model_test.dart
+++ b/test/degree_info_view_model_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:markulator/view_models/degree_info_view_model.dart';
+import 'package:markulator/data/repositories/degree_repository.dart';
+import 'package:markulator/models/degree_model.dart';
+
+class MockDegreeRepository extends Mock implements DegreeRepository {}
+class MockDegree extends Mock implements Degree {}
+
+void main() {
+  late MockDegreeRepository repo;
+  late DegreeInfoViewModel viewModel;
+
+  setUp(() {
+    repo = MockDegreeRepository();
+    viewModel = DegreeInfoViewModel(repository: repo);
+  });
+
+  test('degree is retrieved from repository using setDegree', () {
+    final deg = MockDegree();
+    when(() => repo.degrees).thenReturn({10: deg});
+    viewModel.setDegree(10);
+    expect(viewModel.degree, deg);
+  });
+
+  test('average and weighted averages delegate to repository', () {
+    viewModel.setDegree(2);
+    when(() => repo.averageForYear(1)).thenReturn(0.5);
+    when(() => repo.weightedAverageForYear(1)).thenReturn(0.6);
+    when(() => repo.averageForDegree(2)).thenReturn(0.7);
+    when(() => repo.weightedAverageForDegree(2)).thenReturn(0.8);
+
+    expect(viewModel.averageForYear(1), 0.5);
+    expect(viewModel.weightedAverageForYear(1), 0.6);
+    expect(viewModel.averageForDegree, 0.7);
+    expect(viewModel.weightedAverageForDegree, 0.8);
+
+    verify(() => repo.averageForYear(1)).called(1);
+    verify(() => repo.weightedAverageForYear(1)).called(1);
+    verify(() => repo.averageForDegree(2)).called(1);
+    verify(() => repo.weightedAverageForDegree(2)).called(1);
+  });
+}

--- a/test/degree_overview_view_model_test.dart
+++ b/test/degree_overview_view_model_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:markulator/view_models/degree_overview_view_model.dart';
+import 'package:markulator/data/repositories/degree_repository.dart';
+import 'package:markulator/models/degree_model.dart';
+
+class MockDegreeRepository extends Mock implements DegreeRepository {}
+class MockDegree extends Mock implements Degree {}
+
+void main() {
+  late MockDegreeRepository repo;
+  late DegreeOverviewViewModel viewModel;
+
+  setUp(() {
+    repo = MockDegreeRepository();
+    viewModel = DegreeOverviewViewModel(repository: repo);
+  });
+
+  test('exposes degrees from repository', () {
+    final deg = MockDegree();
+    when(() => repo.degrees).thenReturn({1: deg});
+    expect(viewModel.degrees, {1: deg});
+  });
+
+  test('averageForDegree delegates to repository', () {
+    when(() => repo.averageForDegree(5)).thenReturn(0.6);
+    expect(viewModel.averageForDegree(5), 0.6);
+    verify(() => repo.averageForDegree(5)).called(1);
+  });
+
+  test('weightedAverageForDegree delegates to repository', () {
+    when(() => repo.weightedAverageForDegree(5)).thenReturn(0.7);
+    expect(viewModel.weightedAverageForDegree(5), 0.7);
+    verify(() => repo.weightedAverageForDegree(5)).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `DegreeOverviewViewModel` and `DegreeInfoViewModel`
- register new view models in `MultiProvider`
- test new view models

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68447cf50b0083259c22ee77c2c78bdc