### PR TITLE
Add nested degree sync

### DIFF
--- a/lib/data/repositories/module_repository.dart
+++ b/lib/data/repositories/module_repository.dart
@@ -80,6 +80,15 @@ class ModuleRepository with ChangeNotifier {
     _updateLocalLastUpdated(remoteTime);
   }
 
+  @visibleForTesting
+  Future<void> replaceFromData(
+    List<Map<String, dynamic>> data, [
+    DateTime? remoteTime,
+  ]) async {
+    await _loadFromRemote(data, remoteTime);
+    notifyListeners();
+  }
+
   Future<void> clearLocalModules() async {
     _modules.clear();
     await _storedModules.clear();

--- a/lib/data/services/cloud_service.dart
+++ b/lib/data/services/cloud_service.dart
@@ -6,12 +6,14 @@ import 'package:hive_flutter/hive_flutter.dart';
 import '../../main.dart';
 
 class CloudService with ChangeNotifier {
-  final FirebaseAuth _auth = FirebaseAuth.instance;
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth;
+  final FirebaseFirestore _firestore;
   bool _cloudEnabled = false;
   late final Box _syncBox;
 
-  CloudService() {
+  CloudService({FirebaseAuth? auth, FirebaseFirestore? firestore})
+      : _auth = auth ?? FirebaseAuth.instance,
+        _firestore = firestore ?? FirebaseFirestore.instance {
     _syncBox = Hive.box(syncInfoBox);
     _cloudEnabled = _syncBox.get('cloudEnabled', defaultValue: false) as bool;
     _auth.authStateChanges().listen((_) => notifyListeners());
@@ -46,6 +48,21 @@ class CloudService with ChangeNotifier {
     }
   }
 
+  Future<DateTime?> fetchDegreeRemoteLastUpdated() async {
+    if (user == null) return null;
+    try {
+      final doc = await _firestore
+          .collection('userDegrees')
+          .doc(user!.uid)
+          .get();
+      if (!doc.exists) return null;
+      return (doc.data()?['lastUpdated'] as Timestamp?)?.toDate();
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching remote degree timestamp: $e');
+      return null;
+    }
+  }
+
   Future<void> syncModules(List<Map<String, dynamic>> modules) async {
     if (!cloudEnabled) return;
     final now = DateTime.now();
@@ -57,6 +74,28 @@ class CloudService with ChangeNotifier {
       _updateLastUpdated(now);
     } catch (e) {
       debugPrint('❌ [CloudService] Failed to sync modules: $e');
+    }
+  }
+
+  Future<void> syncDegrees(List<Map<String, dynamic>> degrees) async {
+    if (!cloudEnabled) return;
+    final now = DateTime.now();
+    try {
+      final modules = degrees
+          .expand((d) => (d['years'] as List)
+              .expand((y) => List<Map<String, dynamic>>.from(y['modules'] as List)))
+          .toList();
+      await _firestore.collection('userDegrees').doc(user!.uid).set({
+        'degrees': degrees,
+        'lastUpdated': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+      await _firestore.collection('userModules').doc(user!.uid).set({
+        'modules': modules,
+        'lastUpdated': FieldValue.serverTimestamp(),
+      }, SetOptions(merge: true));
+      _updateLastUpdated(now);
+    } catch (e) {
+      debugPrint('❌ [CloudService] Failed to sync degrees: $e');
     }
   }
 
@@ -81,6 +120,60 @@ class CloudService with ChangeNotifier {
     return null;
   }
 
+  Future<List<Map<String, dynamic>>?> fetchDegreesIfNewer() async {
+    if (!cloudEnabled) return null;
+    try {
+      final doc = await _firestore
+          .collection('userDegrees')
+          .doc(user!.uid)
+          .get();
+      if (doc.exists) {
+        final data = doc.data()!;
+        final remoteTs = (data['lastUpdated'] as Timestamp?)?.toDate();
+        if (remoteTs != null &&
+            (lastUpdated == null || remoteTs.isAfter(lastUpdated!))) {
+          _updateLastUpdated(remoteTs);
+          return List<Map<String, dynamic>>.from(data['degrees'] as List);
+        }
+      } else {
+        // migration from modules collection
+        final legacy = await _firestore
+            .collection('userModules')
+            .doc(user!.uid)
+            .get();
+        if (legacy.exists) {
+          final ldata = legacy.data()!;
+          final modules = List<Map<String, dynamic>>.from(ldata['modules'] as List);
+          await syncDegrees([
+            {
+              'name': 'Default Degree',
+              'years': [
+                {
+                  'yearIndex': 1,
+                  'modules': modules,
+                }
+              ],
+            }
+          ]);
+          return [
+            {
+              'name': 'Default Degree',
+              'years': [
+                {
+                  'yearIndex': 1,
+                  'modules': modules,
+                }
+              ],
+            }
+          ];
+        }
+      }
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching degrees: $e');
+    }
+    return null;
+  }
+
   Future<List<Map<String, dynamic>>?> fetchAllModules({
     bool force = false,
   }) async {
@@ -100,6 +193,27 @@ class CloudService with ChangeNotifier {
       return List<Map<String, dynamic>>.from(data['modules'] as List);
     } catch (e) {
       debugPrint('❌ [CloudService] Error fetching all modules: $e');
+    }
+    return null;
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchAllDegrees({bool force = false}) async {
+    if (!force && !cloudEnabled) return null;
+    if (user == null) return null;
+    try {
+      final doc = await _firestore
+          .collection('userDegrees')
+          .doc(user!.uid)
+          .get();
+      if (!doc.exists) return null;
+      final data = doc.data()!;
+      final remoteTs = (data['lastUpdated'] as Timestamp?)?.toDate();
+      if (remoteTs != null) {
+        _updateLastUpdated(remoteTs);
+      }
+      return List<Map<String, dynamic>>.from(data['degrees'] as List);
+    } catch (e) {
+      debugPrint('❌ [CloudService] Error fetching all degrees: $e');
     }
     return null;
   }

--- a/lib/data/services/module_service.dart
+++ b/lib/data/services/module_service.dart
@@ -9,15 +9,31 @@ class ModuleService {
     await cloudService.syncModules(modules);
   }
 
+  Future<void> syncDegrees(List<Map<String, dynamic>> degrees) async {
+    await cloudService.syncDegrees(degrees);
+  }
+
   Future<List<Map<String, dynamic>>?> fetchModulesIfNewer() async {
     return cloudService.fetchModulesIfNewer();
+  }
+
+  Future<List<Map<String, dynamic>>?> fetchDegreesIfNewer() async {
+    return cloudService.fetchDegreesIfNewer();
   }
 
   Future<List<Map<String, dynamic>>?> fetchAllModules({bool force = false}) {
     return cloudService.fetchAllModules(force: force);
   }
 
+  Future<List<Map<String, dynamic>>?> fetchAllDegrees({bool force = false}) {
+    return cloudService.fetchAllDegrees(force: force);
+  }
+
   Future<DateTime?> fetchRemoteLastUpdated() {
     return cloudService.fetchRemoteLastUpdated();
+  }
+
+  Future<DateTime?> fetchDegreeRemoteLastUpdated() {
+    return cloudService.fetchDegreeRemoteLastUpdated();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,6 +68,7 @@ void main() async {
   );
 
   await moduleRepository.setModuleService(moduleService);
+  await degreeRepository.setModuleService(moduleService);
 
   final SystemInformationService systemInfoProvider =
       SystemInformationService();

--- a/lib/models/degree_model.dart
+++ b/lib/models/degree_model.dart
@@ -20,4 +20,33 @@ class Degree extends HiveObject {
     required this.name,
     required this.years,
   });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'years': years.map((y) => (y as DegreeYear).toMap()).toList(),
+    };
+  }
+
+  static Degree fromMap(
+    Map<String, dynamic> map,
+    Box degreeBox,
+    Box yearBox,
+    Box moduleBox,
+  ) {
+    final degree = Degree(
+      name: map['name'] as String,
+      years: HiveList(yearBox),
+    );
+    degreeBox.add(degree);
+    if (map['years'] != null) {
+      for (final y in (map['years'] as List)) {
+        degree.years.add(
+          DegreeYear.fromMap(Map<String, dynamic>.from(y), yearBox, moduleBox),
+        );
+      }
+    }
+    degree.save();
+    return degree;
+  }
 }

--- a/lib/models/degree_year_model.dart
+++ b/lib/models/degree_year_model.dart
@@ -20,4 +20,32 @@ class DegreeYear extends HiveObject {
     required this.yearIndex,
     required this.modules,
   });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'yearIndex': yearIndex,
+      'modules': modules.map((m) => (m as MarkItem).toMap()).toList(),
+    };
+  }
+
+  static DegreeYear fromMap(
+    Map<String, dynamic> map,
+    Box yearBox,
+    Box moduleBox,
+  ) {
+    final year = DegreeYear(
+      yearIndex: map['yearIndex'] as int,
+      modules: HiveList(moduleBox),
+    );
+    yearBox.add(year);
+    if (map['modules'] != null) {
+      for (final m in (map['modules'] as List)) {
+        year.modules.add(
+          MarkItem.fromMap(Map<String, dynamic>.from(m), moduleBox),
+        );
+      }
+    }
+    year.save();
+    return year;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dev_dependencies:
   build_runner: ^2.1.11
   mocktail: ^1.0.4
   hive_test: ^1.0.1
+  fake_cloud_firestore: ^3.1.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/cloud_service_test.dart
+++ b/test/cloud_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive_test/hive_test.dart';
+
+import 'package:markulator/data/services/cloud_service.dart';
+import 'package:markulator/main.dart';
+
+class MockAuth extends Mock implements FirebaseAuth {}
+class FakeUser extends Fake implements User {
+  @override
+  String get uid => 'test-user';
+}
+
+void main() {
+  setUp(() async {
+    await setUpTestHive();
+    await Hive.openBox(syncInfoBox);
+  });
+
+  tearDown(() async {
+    await tearDownTestHive();
+  });
+
+  test('syncDegrees and fetchDegreesIfNewer round trip', () async {
+    final firestore = FakeFirebaseFirestore();
+    final auth = MockAuth();
+    final user = FakeUser();
+    when(() => auth.currentUser).thenReturn(user);
+    when(() => auth.authStateChanges()).thenAnswer((_) => Stream.value(user));
+
+    final service = CloudService(auth: auth, firestore: firestore);
+    service.setCloudEnabled(true);
+
+    final degrees = [
+      {
+        'name': 'CS',
+        'years': [
+          {
+            'yearIndex': 1,
+            'modules': [
+              {
+                'name': 'A',
+                'mark': 80.0,
+                'weight': 0.0,
+                'autoWeight': true,
+                'credits': 10.0,
+                'contributors': []
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    await service.syncDegrees(degrees);
+
+    final fetched = await service.fetchDegreesIfNewer();
+    expect(fetched, isNotNull);
+    expect(fetched!.first['name'], 'CS');
+  });
+}


### PR DESCRIPTION
## Summary
- add map serialization for Degree and DegreeYear
- support degree sync in CloudService and ModuleService
- integrate DegreeRepository with cloud sync
- add helper for ModuleRepository testing
- update main initialization and add unit test

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684481b3540883259200619c38eb6582