### PR TITLE
Add 'Add Module' button per year

### DIFF
--- a/lib/views/widgets/degree_year_widget.dart
+++ b/lib/views/widgets/degree_year_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 
 import '../../data/repositories/degree_repository.dart';
@@ -6,6 +7,7 @@ import '../../models/degree_year_model.dart';
 import '../../models/module_model.dart';
 import 'module_widget.dart';
 import 'statistics_carousel_widget.dart';
+import 'module_creation_user_input.dart';
 
 class DegreeYearWidget extends StatelessWidget {
   final int degreeId;
@@ -20,6 +22,39 @@ class DegreeYearWidget extends StatelessWidget {
   int _getCrossAxisCount(double width) {
     final count = (width / 160).floor();
     return count > 0 ? count : 1;
+  }
+
+  void _openAddModule(BuildContext context) {
+    final repo = context.read<DegreeRepository>();
+    final sheet = ModuleCreationUserInputWidget(
+      toEdit: null,
+      onAdd: ({required String name, required double mark, required double credits}) {
+        repo.addModule(
+          degreeId,
+          year.key as int,
+          name: name,
+          mark: mark,
+          credits: credits,
+          contributors: null,
+        );
+      },
+    );
+
+    if (Theme.of(context).platform == TargetPlatform.iOS) {
+      showCupertinoModalPopup(
+        context: context,
+        builder: (ctx) => Material(child: sheet),
+      );
+    } else {
+      showModalBottomSheet(
+        isScrollControlled: true,
+        context: context,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(14)),
+        ),
+        builder: (ctx) => sheet,
+      );
+    }
   }
 
   @override
@@ -67,11 +102,20 @@ class DegreeYearWidget extends StatelessWidget {
                 'Year ${year.yearIndex}',
                 style: Theme.of(context).textTheme.titleLarge,
               ),
-              IconButton(
-                icon: const Icon(Icons.delete),
-                tooltip: 'Remove Year',
-                onPressed: () =>
-                    repo.removeYear(degreeId, year.key as int),
+              Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.add),
+                    tooltip: 'Add Module',
+                    onPressed: () => _openAddModule(context),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.delete),
+                    tooltip: 'Remove Year',
+                    onPressed: () =>
+                        repo.removeYear(degreeId, year.key as int),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/views/widgets/module_creation_user_input.dart
+++ b/lib/views/widgets/module_creation_user_input.dart
@@ -8,9 +8,22 @@ import './padded_list_heading_widget.dart';
 import './percentage_input_widget.dart';
 
 class ModuleCreationUserInputWidget extends StatefulWidget {
-  const ModuleCreationUserInputWidget({super.key, required this.toEdit});
+  const ModuleCreationUserInputWidget({
+    super.key,
+    required this.toEdit,
+    this.onAdd,
+  });
 
   final MarkItem? toEdit;
+
+  /// Optional callback invoked when creating a new module.
+  ///
+  /// If null, [ModuleRepository.addModule] is used by default.
+  final void Function({
+    required String name,
+    required double mark,
+    required double credits,
+  })? onAdd;
 
   @override
   State<ModuleCreationUserInputWidget> createState() =>
@@ -145,19 +158,26 @@ class _ModuleCreationUserInputWidgetState
                   ),
                 ),
                 onPressed: () {
+                  final double mark =
+                      double.tryParse(_percentageController.text) ?? 0.0;
+                  final parsedCredits =
+                      double.tryParse(_creditsController.text);
+                  final double credits = parsedCredits ?? 0.0;
                   if (widget.toEdit == null) {
-                    moduleProvider.addModule(
-                      name: _nameController.text,
-                      mark:
-                          (double.tryParse(_percentageController.text) != null)
-                          ? double.parse(_percentageController.text)
-                          : 0,
-                      contributors: null,
-                      credits:
-                          (double.tryParse(_creditsController.text) != null)
-                          ? double.parse(_creditsController.text)
-                          : 0,
-                    );
+                    if (widget.onAdd != null) {
+                      widget.onAdd!(
+                        name: _nameController.text,
+                        mark: mark,
+                        credits: credits,
+                      );
+                    } else {
+                      moduleProvider.addModule(
+                        name: _nameController.text,
+                        mark: mark,
+                        contributors: null,
+                        credits: credits,
+                      );
+                    }
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         content: Text(
@@ -170,14 +190,9 @@ class _ModuleCreationUserInputWidgetState
                     moduleProvider.updateModule(
                       id: widget.toEdit!.key,
                       name: _nameController.text,
-                      mark:
-                          (double.tryParse(_percentageController.text) != null)
-                          ? double.parse(_percentageController.text)
-                          : 0,
+                      mark: mark,
                       credits:
-                          (double.tryParse(_creditsController.text) != null)
-                          ? double.parse(_creditsController.text)
-                          : widget.toEdit!.credits,
+                          parsedCredits != null ? credits : widget.toEdit!.credits,
                     );
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(


### PR DESCRIPTION
## Summary
- allow custom add callback in `ModuleCreationUserInputWidget`
- add an add-module button to each year section
- pop up module creation sheet wired to `DegreeRepository.addModule`
- fix numeric variable types for module creation to compile

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6845923e749c8325a07ecd22f1bf962f